### PR TITLE
sarms: add default DIP settings

### DIFF
--- a/cores/sarms/cfg/mame2mra.toml
+++ b/cores/sarms/cfg/mame2mra.toml
@@ -23,6 +23,9 @@ names=[
 
 [dipsw]
 bitcnt=19   # number 19 is freeze, active low
+defaults=[
+    { value="fc,ff" },
+]
 
 [rom]
 regions=[


### PR DESCRIPTION
Default difficulty level is normal according to manual.