### PR TITLE
ffight: add third button

### DIFF
--- a/cores/cps1/cfg/mame2mra.toml
+++ b/cores/cps1/cfg/mame2mra.toml
@@ -31,7 +31,7 @@ Names = [
     { machine="mtwins",   names="Attack,Jump,Special"},
     { machine="ghouls",   names="Attack,Jump"},
     { machine="dynwar",   names="Attack left,Attack right,Special"},
-    { machine="ffight",   names="Attack,Jump"},
+    { machine="ffight",   names="Attack,Jump,Evade"},
     { machine="forgottn", names="Shoot,Rotate left,Rotate right"},
     { machine="knights",  names="Slay,Jump"},
     { machine="kod",      names="Slay,Jump"},


### PR DESCRIPTION
Although not mentioned in the manual, the third button allows to escape grapples.