### PR TITLE
daimakair: add starting level dipsw

### DIFF
--- a/cores/cps1/cfg/mame2mra.toml
+++ b/cores/cps1/cfg/mame2mra.toml
@@ -88,6 +88,7 @@ rename=[
 ]
 extra=[
     { machine="pang3", name="Freeze", options="On,Off", bits="23" },
+    { setname="daimakair", name="Starting Level", options="-,-,-,-,6,6,5-2,5,4-2,4,3-2,3,2-2,2,1-2,1", bits="16,19" },
 ]
 
 [rom]


### PR DESCRIPTION
dipsw 16,17 in daimakair not only control the number of lives but most importantly the starting level (with dipsw 18,19). I didn't add the number of lives (ie. level 1 starts with 3 lives, level 1-2 with 4, 2 with 5, etc.) but I can if needed.