### PR TITLE
Contra: don't delay cpu_din for Contra and variants

### DIFF
--- a/cores/comsc/hdl/jtcomsc_main_decoder.v
+++ b/cores/comsc/hdl/jtcomsc_main_decoder.v
@@ -90,17 +90,17 @@ always @(*) begin
     pal_cs      = A[15:9] == 7'h03; // 0600-06FF
 end
 
-always @(posedge clk) begin
+always @(*) begin
     case(1'b1)
-        rom_cs:    cpu_din <= rom_data;
-        ram_cs:    cpu_din <= ram_dout;
-        pal_cs:    cpu_din <= pal_dout;
-        in_cs:     cpu_din <= port_in;
+        rom_cs:    cpu_din = rom_data;
+        ram_cs:    cpu_din = ram_dout;
+        pal_cs:    cpu_din = pal_dout;
+        in_cs:     cpu_din = port_in;
         // track_cs:
-        dmp_cs:    cpu_din <= dmp_dout;
-        gfx1_cs:   cpu_din <= gfx1_dout;
-        gfx2_cs:   cpu_din <= gfx2_dout;
-        default:   cpu_din <= 8'hff;
+        dmp_cs:    cpu_din = dmp_dout;
+        gfx1_cs:   cpu_din = gfx1_dout;
+        gfx2_cs:   cpu_din = gfx2_dout;
+        default:   cpu_din = 8'hff;
     endcase
 end
 

--- a/cores/contra/hdl/jtcontra_main.v
+++ b/cores/contra/hdl/jtcontra_main.v
@@ -67,7 +67,10 @@ module jtcontra_main(
 parameter  GAME=0;
 localparam RAM_AW = GAME==0 ? 12 : 13;
 
-wire [ 7:0] ram_dout, cpu_din;
+wire [ 7:0] ram_dout;
+/* verilator lint_off UNOPTFLAT */
+wire [ 7:0] cpu_din;
+/* verilator lint_on UNOPTFLAT */
 wire [15:0] A;
 wire        RnW, irq_n, nmi_n, irq_ack;
 wire        irq_trigger, nmi_trigger;

--- a/cores/contra/hdl/jtcontra_main_decoder.v
+++ b/cores/contra/hdl/jtcontra_main_decoder.v
@@ -75,16 +75,16 @@ always @(*) begin // Decoder 007766 takes as inputs A[15:10] and A[6:5]
     out_cs      = A[15:10] == 6'b0000_00 && A[6:4]==1 && !RnW;  // 18-1F
 end
 
-always @(posedge clk) begin
+always @(*) begin
     case(1'b1)
-        rom_cs:  cpu_din <= rom_data;
-        ram_cs:  cpu_din <= ram_dout;
-        pal_cs:  cpu_din <= pal_dout;
-        in_cs:   cpu_din <= port_in;
-        div_cs:  cpu_din <= div_dout;    // must be above gfx?_cs as it gets selected at the same time
-        gfx1_cs: cpu_din <= gfx1_dout;
-        gfx2_cs: cpu_din <= gfx2_dout;
-        default: cpu_din <= 8'hff;
+        rom_cs:  cpu_din = rom_data;
+        ram_cs:  cpu_din = ram_dout;
+        pal_cs:  cpu_din = pal_dout;
+        in_cs:   cpu_din = port_in;
+        div_cs:  cpu_din = div_dout;    // must be above gfx?_cs as it gets selected at the same time
+        gfx1_cs: cpu_din = gfx1_dout;
+        gfx2_cs: cpu_din = gfx2_dout;
+        default: cpu_din = 8'hff;
     endcase
 end
 

--- a/cores/mx5k/hdl/jtmx5k_main_decoder.v
+++ b/cores/mx5k/hdl/jtmx5k_main_decoder.v
@@ -65,26 +65,26 @@ always @(*) begin // Decoder 051502 takes as inputs A[15:10]
     rom_addr = A[15:12]>=6 ? A[15:0] : { A[15], bank, A[12:0] };
 end
 
-always @(posedge clk) begin
+always @(*) begin
     case(1'b1)
-        rom_cs:  cpu_din <= rom_data;
-        ram_cs:  cpu_din <= ram_dout;
-        io_cs:   cpu_din <= port_in;
-        gfx1_cs: cpu_din <= pal_cs ? pal_dout : gfx1_dout;
-        default: cpu_din <= 8'hff;
+        rom_cs:  cpu_din = rom_data;
+        ram_cs:  cpu_din = ram_dout;
+        io_cs:   cpu_din = port_in;
+        gfx1_cs: cpu_din = pal_cs ? pal_dout : gfx1_dout;
+        default: cpu_din = 8'hff;
     endcase
 end
 
-always @(posedge clk) begin
+always @(*) begin
     case( A[4:2] )
         0:  case( A[1:0] )
-                0: port_in <= {2'b11, joystick1[5:4], joystick1[2], joystick1[3], joystick1[0], joystick1[1]};
-                1: port_in <= {2'b11, joystick2[5:4], joystick2[2], joystick2[3], joystick2[0], joystick2[1]};
-                2: port_in <= {2'b11, joystick2[6],   joystick1[6], dipsw_c[3:0] };
-                3: port_in <= {3'b111, cab_1p, service, coin };
+                0: port_in = {2'b11, joystick1[5:4], joystick1[2], joystick1[3], joystick1[0], joystick1[1]};
+                1: port_in = {2'b11, joystick2[5:4], joystick2[2], joystick2[3], joystick2[0], joystick2[1]};
+                2: port_in = {2'b11, joystick2[6],   joystick1[6], dipsw_c[3:0] };
+                3: port_in = {3'b111, cab_1p, service, coin };
             endcase
-        1: port_in <= A[0] ? dipsw_a : dipsw_b;
-        default: port_in <= 8'hFF;
+        1: port_in = A[0] ? dipsw_a : dipsw_b;
+        default: port_in = 8'hFF;
     endcase
 end
 


### PR DESCRIPTION
MX5K need the port_in as combinatorial, too, otherwise controls won't work.