### PR TITLE
Avoid race condition in verilator test code

### DIFF
--- a/modules/jtframe/bin/jotego_20.04.sh
+++ b/modules/jtframe/bin/jotego_20.04.sh
@@ -6,63 +6,65 @@
 set -e
 
 # Sublime
-wget -qO - https://download.sublimetext.com/sublimehq-pub.gpg | gpg --dearmor | tee /etc/apt/trusted.gpg.d/sublimehq-archive.gpg > /dev/null
+wget -qO - https://download.sublimetext.com/sublimehq-pub.gpg | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/sublimehq-archive.gpg > /dev/null
 echo "deb https://download.sublimetext.com/ apt/stable/" | sudo tee /etc/apt/sources.list.d/sublime-text.list
 
-apt update
-apt upgrade --yes
+sudo apt update
+sudo apt upgrade --yes
 
-apt install --yes --install-suggests apt-transport-https nfs-common
-apt install --yes --install-suggests build-essential git gtkwave figlet xmlstarlet \
+sudo apt install --yes --install-suggests apt-transport-https nfs-common
+sudo apt install --yes --install-suggests build-essential git gtkwave figlet xmlstarlet \
     sublime-text docker
 
 # required by iverilog
-apt install --yes flex gperf bison
+sudo apt install --yes flex gperf bison
 
 # required by MAME
-apt install --yes libqwt-qt5-dev libsdl2-dev libfontconfig1-dev libsdl2-ttf-dev \
+sudo apt install --yes libqwt-qt5-dev libsdl2-dev libfontconfig1-dev libsdl2-ttf-dev \
     libfontconfig-dev libpulse-dev qtbase5-dev qtbase5-dev-tools \
     qtchooser qt5-qmake
 
 # jtcore and jtupdate
-apt install --yes parallel locate python3-pip
-updatedb
+sudo apt install --yes parallel locate python3-pip
+sudo updatedb
 
 # open picoblaze assembler needed for assembling the cheat and beta code
-pip install --upgrade opbasm
+sudo pip install --upgrade opbasm
 
 # as31 to compile 8051/8751 assembler code
-apt install --yes as31
+sudo apt install --yes as31
 
 # asm48 to compile MCS-48 assembler code
 cd /tmp
 git clone https://github.com/jotego/asm48.git
 cd asm48
 make
-cp 8039dasm asm48 /usr/local/bin
+sudo cp 8039dasm asm48 /usr/local/bin
 
 # macro assembler for many, many CPUs
 cd /tmp
 wget http://john.ccac.rwth-aachen.de:8000/ftp/as/source/c_version/asl-current.tar.gz
 tar xfz asl-current.tar.gz
 cd asl-current
+ln -s Makefile.def-samples/Makefile.def-x86_64-unknown-linux Makefile.def
 make
-cp alink asl p2bin p2hex pbind plist *.msg /usr/local/bin
-cp man/* /usr/local/share/man/man1/
+sudo cp alink asl p2bin p2hex pbind plist /usr/local/bin
+sudo mkdir -p /usr/local/share/man/man1/
+sudo cp man/* /usr/local/share/man/man1/
 
 # MRA tool to generate .arc files
 cd /tmp
 git clone https://github.com/mist-devel/mra-tools-c.git
-cd mra-tools-c.git
+cd mra-tools-c
 make -j
-mv mra /usr/local/bin/mra
+sudo mv mra /usr/local/bin/mra
 
 # Verilator
-apt install git help2man perl python3 make autoconf g++ flex bison ccache
-apt install libgoogle-perftools-dev numactl perl-doc
-apt install libfl2  # Ubuntu only (ignore if gives error)
-apt install libfl-dev  # Ubuntu only (ignore if gives error)
-apt install zlibc zlib1g zlib1g-dev  # Ubuntu only (ignore if gives error)
+sudo apt install git help2man perl python3 make autoconf g++ flex bison ccache
+sudo apt install libgoogle-perftools-dev numactl perl-doc
+sudo apt install libfl2  # Ubuntu only (ignore if gives error)
+sudo apt install libfl-dev  # Ubuntu only (ignore if gives error)
+sudo apt install zlib1g zlib1g-dev  # Ubuntu only (ignore if gives error)
 
 cd $HOME
 unset VERILATOR_ROOT
@@ -76,7 +78,7 @@ export VERILATOR_ROOT=`pwd`
 echo export VERILATOR_ROOT=`pwd` >> $HOME/.bashrc
 
 # nice to have
-apt install --yes htop
+sudo apt install --yes htop
 
 # git configuration
 git config --global url.ssh://git@github.com/.insteadOf https://github.com/
@@ -91,13 +93,13 @@ git config --global alias.r "reset --hard"
 git config --global core.whitespace cr-at-eol
 git config --global core.autocrlf input
 # aim for a linear history 
-git config pull.rebase true
+git config --global pull.rebase true
 
 # Go
 GONAME=go1.21.3.linux-amd64.tar.gz
 wget https://go.dev/dl/$GONAME
-rm -rf /usr/local/go && tar -C /usr/local -xzf $GONAME
-rm -f $GONAME
+sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf $GONAME
+sudo rm -f $GONAME
 export PATH=$PATH:/usr/local/go/bin:$HOME/go/bin
 echo export PATH=$PATH:/usr/local/go/bin:$HOME/go/bin >> $HOME/.bashrc
 go install github.com/spf13/cobra-cli@latest

--- a/modules/jtframe/hdl/ver/test.cpp
+++ b/modules/jtframe/hdl/ver/test.cpp
@@ -32,6 +32,7 @@
 // fork
 #include <sys/types.h>
 #include <unistd.h>
+#include <sys/wait.h>
 
 #ifdef _DUMP
     #include "verilated_vcd_c.h"
@@ -1055,6 +1056,10 @@ int main(int argc, char *argv[]) {
                 }
             }
         }
+        // wait until all child processes created with fork() are completed
+        // before exiting.
+        while(wait(NULL) != -1);
+
         if( sim.get_frame()>1 ) fputc('\n',stderr);
     } catch( const char *error ) {
         fputs(error,stderr);


### PR DESCRIPTION
When I tried jtsim -setname xxx it only worked part of the time on ubuntu 22 and never on ubuntu 20. I debugged it and found that the rm -rf frame.raw in the jtsim script was deleted before the forks creating the frame data files were finished running ImageMagick convert(). I have modified test.cpp to wait until the child processes are completed.