### PR TITLE
fix missing begin/end in verilog functions for vivado

### DIFF
--- a/cores/1942/hdl/jt1942_sound.v
+++ b/cores/1942/hdl/jt1942_sound.v
@@ -157,8 +157,10 @@ jtframe_sysz80 #(.RAM_AW(11)) u_cpu(
 );
 
 function [1:0] bcdir( input cs );
+begin
     bcdir[0] = cs       & ~(hige ? main_wr_n : wr_n); // bdir pin
     bcdir[1] = bcdir[0] &  (hige ? main_a0   :~A[0]); // bc pin
+end
 endfunction
 
 wire bdir0, bc0;

--- a/cores/exed/hdl/jtexed_sound.v
+++ b/cores/exed/hdl/jtexed_sound.v
@@ -127,8 +127,10 @@ jtframe_sysz80 #(.RAM_AW(11)) u_cpu(
 );
 
 function [1:0] bcdir( input cs );
+begin
     bcdir[0] = cs       & ~wr_n; // bdir pin
     bcdir[1] = bcdir[0] & ~A[0]; // bc pin
+end
 endfunction
 
 wire bdir0, bc0;

--- a/cores/simson/hdl/jtcolmix_053251.v
+++ b/cores/simson/hdl/jtcolmix_053251.v
@@ -89,8 +89,10 @@ always @* begin
 end
 
 function opaque( input full, input [7:0] col );
+begin
     opaque = ~|col[3:0];
     if(full) opaque = opaque & ~|col[7:4];
+end
 endfunction
 
 `ifdef SIMULATION


### PR DESCRIPTION
Hi, I am pleased to report that 43 cores already work with MiSTeX on a Xilinx A100T.
The core code has had excellent portability (probably because of the use of the verilator linter).
I only encountered this one minor issue: That vivado wants a begin/end block inside
verilog function declarations.

Kind regards,
Hans