### PR TITLE
cores/fround/hdl/jt00778x.v: either none or all wires need to be initialized in a combined declaration

### DIFF
--- a/cores/fround/hdl/jt00778x.v
+++ b/cores/fround/hdl/jt00778x.v
@@ -97,8 +97,8 @@ reg         inzone, hs_l, done, busy_l, skip;
 reg  [ 8:0] ydiff, y, vlatch;
 reg  [ 7:0] scan_obj, lut_obj, lut_dst;
 reg  [ 6:0] ydf;
-wire        flip = 0, busy_g;
-
+wire        flip = 0;
+wire        busy_g;
 
 assign oram_addr = !dma_bsy ? { 3'b110, `ifdef NOLUTFB
                 scan_obj, scan_sub[1:0] `else lut_obj, ~lut_sub[1:0] `endif } :


### PR DESCRIPTION
Another small vivado hiccup. 