### PR TITLE
Par sprites

### DIFF
--- a/cores/simson/hdl/jt053246.sv
+++ b/cores/simson/hdl/jt053246.sv
@@ -49,7 +49,7 @@ module jt053246(    // sprite logic
     output reg        vflip,
     output reg [ 8:0] hpos,
     output     [ 3:0] ysub,
-    output reg [11:0] hzoom,//Cambios
+    output reg [ 9:0] hzoom,//Cambios
     output reg        hz_keep,
 
     // base video
@@ -79,7 +79,7 @@ localparam [2:0] REG_XOFF  = 0, // X offset
                  REG_CFG   = 2; // interrupt control, ROM read
 
 reg  [18:0] yz_add;
-reg  [11:0] vzoom/*,hzoomb*/;
+reg  [11:0] vzoom,hzoomb;
 reg  [ 9:0] /*vzoom,*/ y, y2, x, ydiff, ydiff_b, xadj, yadj, ywrap, yw0;
 reg  [ 8:0] vlatch, ymove, full_h, vscl, hscl, full_w;
 reg  [ 7:0] scan_obj; // max 256 objects
@@ -98,7 +98,7 @@ wire [ 1:0] nx_mir, hsz, vsz;
 wire        dma_wel, dma_weh, dma_trig, last_obj, vb_rd,
             cpu_bsy, ghf, gvf, mode8, dma_en, flicker;
 reg  [ 8:0] zoffset [0:255];
-reg  [ 8:0] pzoffset[0:15 ];
+reg  [ 3:0] pzoffset[0:15 ];
 
 assign ghf       = cfg[0]; // global flip
 assign gvf       = cfg[1];
@@ -119,8 +119,8 @@ always @(negedge clk) cen2 <= ~cen2;
 always @(posedge clk) begin
     xadj <= xoffset - (k44_en ? 10'd108 : 10'd61);
     yadj <= yoffset + (k44_en ? 10'h10f : {5'o10, simson, 4'hf} ); // 10'h11f for Simpsons, 10'h10f for Vendetta (and Parodius)
-    vscl <= k44_en? red_offset(vzoom): zoffset[ vzoom[7:0] ];
-    hscl <= k44_en? red_offset(hzoom): zoffset[ hzoom[7:0] ];
+    vscl <= k44_en? red_offset(vzoom,zoffset,pzoffset) : zoffset[ vzoom[7:0] ];
+    hscl <= k44_en? red_offset(hzoomb,zoffset,pzoffset): zoffset[ hzoom[7:0] ];
     /* verilator lint_off WIDTH */
     yz_add  <= vzoom*ydiff_b; // vzoom < 10'h40 enlarge, >10'h40 reduce
                               // opposite to the one in Aliens, which always
@@ -139,13 +139,13 @@ function [8:0] zmove( input [1:0] sz, input[8:0] scl );
     endcase
 endfunction
 
-function [8:0] red_offset( input [11:0] zoom);
+function [8:0] red_offset( input [11:0] zoom, input [ 8:0] offset1 [0:255], input [3:0] offset2[0:15]);
     case( zoom[11:8] )
-        0:       red_offset = zoffset [zoom[7:0]];
-        1:       red_offset = pzoffset[zoom[7:4]];
-        2:       red_offset = 3;
-        4,3:     red_offset = 2;
-        default: red_offset = 1;
+        0:       red_offset =       offset1 [zoom[7:0]];
+        1:       red_offset = {5'b0,offset2 [zoom[7:4]]};
+        2:       red_offset =  9'd3;
+        4,3:     red_offset =  9'd2;
+        default: red_offset =  9'd1;
     endcase
 endfunction 
 
@@ -205,6 +205,7 @@ always @(posedge clk, posedge rst) begin
         vflip    <= 0;
         vzoom    <= 0;
         hzoom    <= 0;
+        hzoomb   <= 0;
         hz_keep  <= 0;
         indr     <= 0;
         hhalf    <= 0;
@@ -246,17 +247,17 @@ always @(posedge clk, posedge rst) begin
                     x <=  x - xadj;
                     y <=  ywrap;
                     vzoom <= scan_even[11:0];
-                    hzoom<= sq ? scan_even[11:0] : scan_odd[11:0];
-                    //hzoom <= sq ? scan_even[ 9:0] : scan_odd[ 9:0];
+                    hzoomb<= sq ? scan_even[11:0] : scan_odd[11:0];
+                    hzoom <= sq ? scan_even[ 9:0] : scan_odd[ 9:0];
                     // p_vzoom <= scan_even[11:8];
                     // p_hzoom <= sq ? scan_even[11:8] : scan_odd[11:8];
-/*                    if( k44_en ) begin //
+                    if( k44_en ) begin //
                         if(scan_odd>16'h3ff) hzoom <= 10'h3ff;
                         if(scan_even>16'h3ff) begin
-                            vzoom <= 10'h3ff;
+                            // vzoom <= 10'h3ff;
                             if( sq ) hzoom <= 10'h3ff;
                         end
-                    end*/
+                    end
                 end
                 3: begin
                     { vmir, hmir } <= nx_mir;
@@ -289,7 +290,7 @@ always @(posedge clk, posedge rst) begin
                     if( (!dr_start && !dr_busy) || !inzone ) begin
                         {code[4],code[2],code[0]} <= hcode + hsum;
                         if( hstep==0 ) begin
-                            hpos <= x[8:0] - zmove( hsz, hscl );
+                            hpos <= x[8:0] - zmove( hsz, hscl ) - 9'b1;
                         end else begin
                             hpos <= hpos + 9'h10;
                             hz_keep <= 1;

--- a/cores/simson/hdl/jt053246.sv
+++ b/cores/simson/hdl/jt053246.sv
@@ -248,8 +248,8 @@ always @(posedge clk, posedge rst) begin
                     vzoom <= scan_even[11:0];
                     hzoom <= sq ? scan_even[11:0] : scan_odd[11:0];
                     if( !k44_en) begin
-                        vzoom <= {2'b0,scan_even[9:0]};
-                        hzoom <= sq ? {2'b0,scan_even[9:0]}  : ({2'b0,scan_odd[:0]});
+                        vzoom[11:10] <= 0;
+                        hzoom[11:10] <= 0;
                     end
                 end
                 3: begin

--- a/cores/simson/hdl/jt053246.sv
+++ b/cores/simson/hdl/jt053246.sv
@@ -49,7 +49,7 @@ module jt053246(    // sprite logic
     output reg        vflip,
     output reg [ 8:0] hpos,
     output     [ 3:0] ysub,
-    output reg [ 9:0] hzoom,//Cambios
+    output reg [11:0] hzoom,
     output reg        hz_keep,
 
     // base video
@@ -79,8 +79,8 @@ localparam [2:0] REG_XOFF  = 0, // X offset
                  REG_CFG   = 2; // interrupt control, ROM read
 
 reg  [18:0] yz_add;
-reg  [11:0] vzoom,hzoomb;
-reg  [ 9:0] /*vzoom,*/ y, y2, x, ydiff, ydiff_b, xadj, yadj, ywrap, yw0;
+reg  [11:0] vzoom;
+reg  [ 9:0] y, y2, x, ydiff, ydiff_b, xadj, yadj, ywrap, yw0;
 reg  [ 8:0] vlatch, ymove, full_h, vscl, hscl, full_w;
 reg  [ 7:0] scan_obj; // max 256 objects
 reg  [ 3:0] size;
@@ -120,7 +120,7 @@ always @(posedge clk) begin
     xadj <= xoffset - (k44_en ? 10'd108 : 10'd61);
     yadj <= yoffset + (k44_en ? 10'h10f : {5'o10, simson, 4'hf} ); // 10'h11f for Simpsons, 10'h10f for Vendetta (and Parodius)
     vscl <= k44_en? red_offset(vzoom, zoffset,pzoffset):  zoffset[ vzoom[7:0] ];
-    hscl <= k44_en? red_offset(hzoomb,zoffset,pzoffset):  zoffset[ hzoom[7:0] ];
+    hscl <= k44_en? red_offset(hzoom, zoffset,pzoffset):  zoffset[ hzoom[7:0] ];
     /* verilator lint_off WIDTH */
     yz_add  <= vzoom[9:0]*ydiff_b; // vzoom < 10'h40 enlarge, >10'h40 reduce
                                    // opposite to the one in Aliens, which always
@@ -205,7 +205,6 @@ always @(posedge clk, posedge rst) begin
         vflip    <= 0;
         vzoom    <= 0;
         hzoom    <= 0;
-        hzoomb   <= 0;
         hz_keep  <= 0;
         indr     <= 0;
         hhalf    <= 0;
@@ -247,21 +246,11 @@ always @(posedge clk, posedge rst) begin
                     x <=  x - xadj;
                     y <=  ywrap;
                     vzoom <= scan_even[11:0];
-                    hzoom <= sq ? scan_even[ 9:0] : scan_odd[ 9:0];
-                    hzoomb <= sq ? scan_even[11:0] : scan_odd[11:0];
-/*                    if( !k44_en) begin
-                        vzoom <= scan_even[11:0] << 2;
-                        hzoom <= sq ? (scan_even[11:0] << 2) : (scan_odd[11:0] << 2);
-                    end*/
-                    // p_vzoom <= scan_even[11:8];
-                    // p_hzoom <= sq ? scan_even[11:8] : scan_odd[11:8];
-/*                    if( k44_en ) begin //
-                        if(scan_odd>16'h3ff) hzoom <= 10'h3ff;
-                        if(scan_even>16'h3ff) begin
-                            // vzoom <= 10'h3ff;
-                            if( sq ) hzoom <= 10'h3ff;
-                        end
-                    end*/
+                    hzoom <= sq ? scan_even[11:0] : scan_odd[11:0];
+                    if( !k44_en) begin
+                        vzoom <= {2'b0,scan_even[9:0]};
+                        hzoom <= sq ? {2'b0,scan_even[9:0]}  : ({2'b0,scan_odd[:0]});
+                    end
                 end
                 3: begin
                     { vmir, hmir } <= nx_mir;

--- a/cores/simson/hdl/jt053246.sv
+++ b/cores/simson/hdl/jt053246.sv
@@ -127,7 +127,7 @@ always @(posedge clk) begin
                                    // shrunk for non-zero zoom values
     /* verilator lint_on WIDTH */
     yw0   = y + yadj;
-    ywrap = yw0 > 10'h200 ? yw0+10'h121 : yw0;
+    ywrap = yw0 > 10'h200 ? yw0+10'h187 : yw0;
 end
 
 function [8:0] zmove( input [1:0] sz, input[8:0] scl );

--- a/cores/simson/hdl/jt053246.sv
+++ b/cores/simson/hdl/jt053246.sv
@@ -83,7 +83,7 @@ reg  [11:0] vzoom,hzoomb;
 reg  [ 9:0] /*vzoom,*/ y, y2, x, ydiff, ydiff_b, xadj, yadj, ywrap, yw0;
 reg  [ 8:0] vlatch, ymove, full_h, vscl, hscl, full_w;
 reg  [ 7:0] scan_obj; // max 256 objects
-reg  [ 3:0] size/*, p_vzoom, p_hzoom*/;//
+reg  [ 3:0] size;
 reg  [ 2:0] hstep, hcode, hsum, vsum;
 reg  [ 1:0] scan_sub, reserved;
 reg         inzone, hs_l, done, hdone,
@@ -119,12 +119,12 @@ always @(negedge clk) cen2 <= ~cen2;
 always @(posedge clk) begin
     xadj <= xoffset - (k44_en ? 10'd108 : 10'd61);
     yadj <= yoffset + (k44_en ? 10'h10f : {5'o10, simson, 4'hf} ); // 10'h11f for Simpsons, 10'h10f for Vendetta (and Parodius)
-    vscl <= k44_en? red_offset(vzoom,zoffset,pzoffset) : zoffset[ vzoom[7:0] ];
-    hscl <= k44_en? red_offset(hzoomb,zoffset,pzoffset): zoffset[ hzoom[7:0] ];
+    vscl <= k44_en? red_offset(vzoom, zoffset,pzoffset):  zoffset[ vzoom[7:0] ];
+    hscl <= k44_en? red_offset(hzoomb,zoffset,pzoffset):  zoffset[ hzoom[7:0] ];
     /* verilator lint_off WIDTH */
-    yz_add  <= vzoom*ydiff_b; // vzoom < 10'h40 enlarge, >10'h40 reduce
-                              // opposite to the one in Aliens, which always
-                              // shrunk for non-zero zoom values
+    yz_add  <= vzoom[9:0]*ydiff_b; // vzoom < 10'h40 enlarge, >10'h40 reduce
+                                   // opposite to the one in Aliens, which always
+                                   // shrunk for non-zero zoom values
     /* verilator lint_on WIDTH */
     yw0   = y + yadj;
     ywrap = yw0 > 10'h200 ? yw0+10'h121 : yw0;
@@ -247,17 +247,21 @@ always @(posedge clk, posedge rst) begin
                     x <=  x - xadj;
                     y <=  ywrap;
                     vzoom <= scan_even[11:0];
-                    hzoomb<= sq ? scan_even[11:0] : scan_odd[11:0];
                     hzoom <= sq ? scan_even[ 9:0] : scan_odd[ 9:0];
+                    hzoomb <= sq ? scan_even[11:0] : scan_odd[11:0];
+/*                    if( !k44_en) begin
+                        vzoom <= scan_even[11:0] << 2;
+                        hzoom <= sq ? (scan_even[11:0] << 2) : (scan_odd[11:0] << 2);
+                    end*/
                     // p_vzoom <= scan_even[11:8];
                     // p_hzoom <= sq ? scan_even[11:8] : scan_odd[11:8];
-                    if( k44_en ) begin //
+/*                    if( k44_en ) begin //
                         if(scan_odd>16'h3ff) hzoom <= 10'h3ff;
                         if(scan_even>16'h3ff) begin
                             // vzoom <= 10'h3ff;
                             if( sq ) hzoom <= 10'h3ff;
                         end
-                    end
+                    end*/
                 end
                 3: begin
                     { vmir, hmir } <= nx_mir;

--- a/cores/simson/hdl/jtsimson_obj.v
+++ b/cores/simson/hdl/jtsimson_obj.v
@@ -78,7 +78,7 @@ wire [ 9:0] attr;     // OC pins
 wire        hflip, vflip, hz_keep, pre_cs;
 wire [ 8:0] hpos;
 wire [ 3:0] ysub;
-wire [11:0] hzoom;
+wire [ 9:0] hzoom;
 wire [31:0] sorted;
 wire        pen15;
 
@@ -174,7 +174,7 @@ jt053246 u_scan(    // sprite logic
 
 jtframe_objdraw #(
     .CW(16),.PW(4+10+2),.LATCH(1),.SWAPH(1),
-    .ZW(12),.ZI(6),.ZENLARGE(1), //ZW=12?
+    .ZW(10),.ZI(6),.ZENLARGE(1), //ZW=12?
     .FLIP_OFFSET(9'h12),.KEEP_OLD(1)
 ) u_draw(
     .rst        ( rst       ),

--- a/cores/simson/hdl/jtsimson_obj.v
+++ b/cores/simson/hdl/jtsimson_obj.v
@@ -78,7 +78,7 @@ wire [ 9:0] attr;     // OC pins
 wire        hflip, vflip, hz_keep, pre_cs;
 wire [ 8:0] hpos;
 wire [ 3:0] ysub;
-wire [ 9:0] hzoom;
+wire [11:0] hzoom;
 wire [31:0] sorted;
 wire        pen15;
 
@@ -174,7 +174,7 @@ jt053246 u_scan(    // sprite logic
 
 jtframe_objdraw #(
     .CW(16),.PW(4+10+2),.LATCH(1),.SWAPH(1),
-    .ZW(10),.ZI(6),.ZENLARGE(1),
+    .ZW(12),.ZI(6),.ZENLARGE(1), //ZW=12?
     .FLIP_OFFSET(9'h12),.KEEP_OLD(1)
 ) u_draw(
     .rst        ( rst       ),

--- a/cores/simson/hdl/jtsimson_obj.v
+++ b/cores/simson/hdl/jtsimson_obj.v
@@ -174,7 +174,7 @@ jt053246 u_scan(    // sprite logic
 
 jtframe_objdraw #(
     .CW(16),.PW(4+10+2),.LATCH(1),.SWAPH(1),
-    .ZW(10),.ZI(6),.ZENLARGE(1), //ZW=12?
+    .ZW(10),.ZI(6),.ZENLARGE(1),
     .FLIP_OFFSET(9'h12),.KEEP_OLD(1)
 ) u_draw(
     .rst        ( rst       ),

--- a/cores/simson/hdl/jtsimson_obj.v
+++ b/cores/simson/hdl/jtsimson_obj.v
@@ -78,7 +78,7 @@ wire [ 9:0] attr;     // OC pins
 wire        hflip, vflip, hz_keep, pre_cs;
 wire [ 8:0] hpos;
 wire [ 3:0] ysub;
-wire [ 9:0] hzoom;
+wire [11:0] hzoom;
 wire [31:0] sorted;
 wire        pen15;
 
@@ -174,7 +174,7 @@ jt053246 u_scan(    // sprite logic
 
 jtframe_objdraw #(
     .CW(16),.PW(4+10+2),.LATCH(1),.SWAPH(1),
-    .ZW(10),.ZI(6),.ZENLARGE(1),
+    .ZW(12),.ZI(6),.ZENLARGE(1),
     .FLIP_OFFSET(9'h12),.KEEP_OLD(1)
 ) u_draw(
     .rst        ( rst       ),


### PR DESCRIPTION
Increased the value for ywrap to avoid the appearance of the cat-boat and the balloon from the top of the screen at the end of the first stages of both Parodius and The Simpsons
![22](https://github.com/jotego/jtcores/assets/168713859/2291768e-9072-4e84-811d-8604af21c296)
![19](https://github.com/jotego/jtcores/assets/168713859/c49530c3-6ad4-4468-b20e-d9012f1fcc07)
