### PR TITLE
Issue727

### DIFF
--- a/cores/s18/hdl/jts18_colmix.v
+++ b/cores/s18/hdl/jts18_colmix.v
@@ -49,12 +49,21 @@ wire [7:0] ex_r, ex_g, ex_b;
 reg  [7:0] pr, pg, pb;
 wire       s16_blank, vdp_blank, vdp_sel_o, obj;
 reg        vdp_sel, nblnk;
+reg  [4:0] tilemap_l, tilemap_l2;
+reg  [1:0] obj_prio_l, obj_prio_l2;
 
 assign ex_r = {s16_r,s16_r[5:4]};
 assign ex_g = {s16_g,s16_g[5:4]};
 assign ex_b = {s16_b,s16_b[5:4]};
 assign s16_blank = {ex_r,ex_g,ex_b}==0;
-assign obj = {sa,sb,fix}==0;
+assign obj = {tilemap_l2[4:2]}==0;
+
+always @(posedge clk) if (pxl_cen) begin
+    tilemap_l <= {sa, sb, fix, s1_pri, s2_pri};
+    tilemap_l2 <= tilemap_l;
+    obj_prio_l <= obj_prio;
+    obj_prio_l2 <= obj_prio_l;
+end
 
 always @(posedge clk) begin
     // case( vdp_prio + debug_bus[6:4])
@@ -91,13 +100,13 @@ jts18_vdp_pri_test #( .VBLs(80)) u_vdp_test(
     .rst        ( rst       ),
     .debug_bus  ( debug_bus ),
     .vdp_prio   ( vdp_prio  ),
-    .obj_prio   ( obj_prio  ),
+    .obj_prio   ( obj_prio_l2 ),
     .buttons    ( joystick1 ),
-    .sa         ( sa        ),
-    .sb         ( sb        ),
-    .fix        ( fix       ),
-    .s1_pri     ( s1_pri    ),
-    .s2_pri     ( s2_pri    ),
+    .sa         ( tilemap_l2[4] ),
+    .sb         ( tilemap_l2[3] ),
+    .fix        ( tilemap_l2[2] ),
+    .s1_pri     ( tilemap_l2[1] ),
+    .s2_pri     ( tilemap_l2[0] ),
     .obj        ( obj       ),
     .LVBL       ( LVBL      ),
     .vdp_sel    ( vdp_sel_o ),

--- a/cores/shanon/hdl/jtshanon_coldac.v
+++ b/cores/shanon/hdl/jtshanon_coldac.v
@@ -32,124 +32,16 @@ module jtshanon_coldac(
     output reg [5:0] rout, gout, bout
 );
 
-reg  [5:0] lvl;
-reg  [4:0] act;
 wire [4:0] gray;
-reg  [3:0] cnt;
+wire [5:0] lvl_r, lvl_g, lvl_b;
+
+jtshanon_coldac_lvldec dec_r(gray_n ? rin : gray, sh, hilo, lvl_r);
+jtshanon_coldac_lvldec dec_g(gray_n ? gin : gray, sh, hilo, lvl_g);
+jtshanon_coldac_lvldec dec_b(gray_n ? bin : gray, sh, hilo, lvl_b);
 
 always @(posedge clk) begin
-    cnt <= cnt<<1;
-    if(pxl_cen) begin
-        cnt <= 1;
-        act <= rin;
-    end
-    if( cnt[0] )  act        <=  gin;
-    if( cnt[1] ) {act, rout} <= {bin, lvl};
-    if( cnt[2] )       gout  <=       lvl;
-    if( cnt[3] )       bout  <=       lvl;
-    if( !gray_n ) act <= gray;
+    {rout, gout, bout} <= {lvl_r, lvl_g, lvl_b};
     if( !en ) {rout,gout,bout} <= 0;
-    casez( {act,sh,hilo})
-        // normal tones
-        {5'd00, 2'b0?}: lvl <= 0;
-        {5'd01, 2'b0?}: lvl <= 2;
-        {5'd02, 2'b0?}: lvl <= 4;
-        {5'd03, 2'b0?}: lvl <= 5;
-        {5'd04, 2'b0?}: lvl <= 7;
-        {5'd05, 2'b0?}: lvl <= 9;
-        {5'd06, 2'b0?}: lvl <= 10;
-        {5'd07, 2'b0?}: lvl <= 12;
-        {5'd08, 2'b0?}: lvl <= 15;
-        {5'd09, 2'b0?}: lvl <= 16;
-        {5'd10, 2'b0?}: lvl <= 18;
-        {5'd11, 2'b0?}: lvl <= 20;
-        {5'd12, 2'b0?}: lvl <= 22;
-        {5'd13, 2'b0?}: lvl <= 24;
-        {5'd14, 2'b0?}: lvl <= 25;
-        {5'd15, 2'b0?}: lvl <= 27;
-        {5'd16, 2'b0?}: lvl <= 31;
-        {5'd17, 2'b0?}: lvl <= 33;
-        {5'd18, 2'b0?}: lvl <= 35;
-        {5'd19, 2'b0?}: lvl <= 36;
-        {5'd20, 2'b0?}: lvl <= 38;
-        {5'd21, 2'b0?}: lvl <= 40;
-        {5'd22, 2'b0?}: lvl <= 42;
-        {5'd23, 2'b0?}: lvl <= 43;
-        {5'd24, 2'b0?}: lvl <= 46;
-        {5'd25, 2'b0?}: lvl <= 47;
-        {5'd26, 2'b0?}: lvl <= 49;
-        {5'd27, 2'b0?}: lvl <= 51;
-        {5'd28, 2'b0?}: lvl <= 53;
-        {5'd29, 2'b0?}: lvl <= 55;
-        {5'd30, 2'b0?}: lvl <= 56;
-        {5'd31, 2'b0?}: lvl <= 58;
-        // dimmed
-        {5'd00, 2'b10}: lvl <= 0;
-        {5'd01, 2'b10}: lvl <= 0;
-        {5'd02, 2'b10}: lvl <= 1;
-        {5'd03, 2'b10}: lvl <= 1;
-        {5'd04, 2'b10}: lvl <= 1;
-        {5'd05, 2'b10}: lvl <= 2; // values above this point were rounded up
-        {5'd06, 2'b10}: lvl <= 2; // to avoid too many zero entries
-        {5'd07, 2'b10}: lvl <= 3;
-        {5'd08, 2'b10}: lvl <= 4;
-        {5'd09, 2'b10}: lvl <= 5;
-        {5'd10, 2'b10}: lvl <= 7;
-        {5'd11, 2'b10}: lvl <= 8;
-        {5'd12, 2'b10}: lvl <= 9;
-        {5'd13, 2'b10}: lvl <= 11;
-        {5'd14, 2'b10}: lvl <= 12;
-        {5'd15, 2'b10}: lvl <= 14;
-        {5'd16, 2'b10}: lvl <= 17;
-        {5'd17, 2'b10}: lvl <= 18;
-        {5'd18, 2'b10}: lvl <= 20;
-        {5'd19, 2'b10}: lvl <= 21;
-        {5'd20, 2'b10}: lvl <= 23;
-        {5'd21, 2'b10}: lvl <= 24;
-        {5'd22, 2'b10}: lvl <= 25;
-        {5'd23, 2'b10}: lvl <= 27;
-        {5'd24, 2'b10}: lvl <= 29;
-        {5'd25, 2'b10}: lvl <= 30;
-        {5'd26, 2'b10}: lvl <= 32;
-        {5'd27, 2'b10}: lvl <= 33;
-        {5'd28, 2'b10}: lvl <= 34;
-        {5'd29, 2'b10}: lvl <= 36;
-        {5'd30, 2'b10}: lvl <= 37;
-        {5'd31, 2'b10}: lvl <= 38;
-        // bright
-        {5'd00, 2'b11}: lvl <= 17;
-        {5'd01, 2'b11}: lvl <= 18;
-        {5'd02, 2'b11}: lvl <= 20;
-        {5'd03, 2'b11}: lvl <= 21;
-        {5'd04, 2'b11}: lvl <= 23;
-        {5'd05, 2'b11}: lvl <= 24;
-        {5'd06, 2'b11}: lvl <= 25;
-        {5'd07, 2'b11}: lvl <= 27;
-        {5'd08, 2'b11}: lvl <= 29;
-        {5'd09, 2'b11}: lvl <= 30;
-        {5'd10, 2'b11}: lvl <= 32;
-        {5'd11, 2'b11}: lvl <= 33;
-        {5'd12, 2'b11}: lvl <= 34;
-        {5'd13, 2'b11}: lvl <= 36;
-        {5'd14, 2'b11}: lvl <= 37;
-        {5'd15, 2'b11}: lvl <= 38;
-        {5'd16, 2'b11}: lvl <= 42;
-        {5'd17, 2'b11}: lvl <= 43;
-        {5'd18, 2'b11}: lvl <= 45;
-        {5'd19, 2'b11}: lvl <= 46;
-        {5'd20, 2'b11}: lvl <= 47;
-        {5'd21, 2'b11}: lvl <= 49;
-        {5'd22, 2'b11}: lvl <= 50;
-        {5'd23, 2'b11}: lvl <= 51;
-        {5'd24, 2'b11}: lvl <= 54;
-        {5'd25, 2'b11}: lvl <= 55;
-        {5'd26, 2'b11}: lvl <= 56;
-        {5'd27, 2'b11}: lvl <= 58;
-        {5'd28, 2'b11}: lvl <= 59;
-        {5'd29, 2'b11}: lvl <= 60;
-        {5'd30, 2'b11}: lvl <= 62;
-        {5'd31, 2'b11}: lvl <= 63;
-    endcase
 end
 
 // gray out logic comes directly from Furrtek's model
@@ -188,5 +80,118 @@ assign G1ADJ = ^{~&{~&{JETA_A, GYPU}, ~HORA}, ~&{~CAGA, BULU}}; // DOCY, COPU, D
 assign G2ADJ = ^{~&{~CAGA, ~&{BULU, HORA}, ~&{JETA_A, GYPU, BULU}}, ~&{~GYVE, HUTO}};   // ATOK, ETYB, BYXO, HAXO, HUNA
 assign G3ADJ = ^{~&{~GYVE, ~&{HUTO, CAGA}, ~&{BULU, HUTO, HORA}, ~&{JETA_A, GYPU, BULU, HUTO}}, ~&{CUFO, DUDO}};    // BEWA, DAMY, BOCA, DYJU, ETEC, GYLO
 assign G4ADJ = &{CUFO, ~&{DUDO, GYVE}, ~&{HUTO, DUDO, CAGA}, ~&{BULU, GYPU, JETA_A, DUDO, HUTO}, ~&{BULU, HUTO, DUDO, HORA}};   // FERO, JYSA, CUGO, FUGU, JANO
+
+endmodule
+
+module jtshanon_coldac_lvldec(
+    input      [4:0] act,
+    input            sh,
+    input            hilo,
+    output reg [5:0] lvl
+);
+
+always @(*) begin
+    casez( {act,sh,hilo})
+        // normal tones
+        {5'd00, 2'b0?}: lvl = 0;
+        {5'd01, 2'b0?}: lvl = 2;
+        {5'd02, 2'b0?}: lvl = 4;
+        {5'd03, 2'b0?}: lvl = 5;
+        {5'd04, 2'b0?}: lvl = 7;
+        {5'd05, 2'b0?}: lvl = 9;
+        {5'd06, 2'b0?}: lvl = 10;
+        {5'd07, 2'b0?}: lvl = 12;
+        {5'd08, 2'b0?}: lvl = 15;
+        {5'd09, 2'b0?}: lvl = 16;
+        {5'd10, 2'b0?}: lvl = 18;
+        {5'd11, 2'b0?}: lvl = 20;
+        {5'd12, 2'b0?}: lvl = 22;
+        {5'd13, 2'b0?}: lvl = 24;
+        {5'd14, 2'b0?}: lvl = 25;
+        {5'd15, 2'b0?}: lvl = 27;
+        {5'd16, 2'b0?}: lvl = 31;
+        {5'd17, 2'b0?}: lvl = 33;
+        {5'd18, 2'b0?}: lvl = 35;
+        {5'd19, 2'b0?}: lvl = 36;
+        {5'd20, 2'b0?}: lvl = 38;
+        {5'd21, 2'b0?}: lvl = 40;
+        {5'd22, 2'b0?}: lvl = 42;
+        {5'd23, 2'b0?}: lvl = 43;
+        {5'd24, 2'b0?}: lvl = 46;
+        {5'd25, 2'b0?}: lvl = 47;
+        {5'd26, 2'b0?}: lvl = 49;
+        {5'd27, 2'b0?}: lvl = 51;
+        {5'd28, 2'b0?}: lvl = 53;
+        {5'd29, 2'b0?}: lvl = 55;
+        {5'd30, 2'b0?}: lvl = 56;
+        {5'd31, 2'b0?}: lvl = 58;
+        // dimmed
+        {5'd00, 2'b10}: lvl = 0;
+        {5'd01, 2'b10}: lvl = 0;
+        {5'd02, 2'b10}: lvl = 1;
+        {5'd03, 2'b10}: lvl = 1;
+        {5'd04, 2'b10}: lvl = 1;
+        {5'd05, 2'b10}: lvl = 2; // values above this point were rounded up
+        {5'd06, 2'b10}: lvl = 2; // to avoid too many zero entries
+        {5'd07, 2'b10}: lvl = 3;
+        {5'd08, 2'b10}: lvl = 4;
+        {5'd09, 2'b10}: lvl = 5;
+        {5'd10, 2'b10}: lvl = 7;
+        {5'd11, 2'b10}: lvl = 8;
+        {5'd12, 2'b10}: lvl = 9;
+        {5'd13, 2'b10}: lvl = 11;
+        {5'd14, 2'b10}: lvl = 12;
+        {5'd15, 2'b10}: lvl = 14;
+        {5'd16, 2'b10}: lvl = 17;
+        {5'd17, 2'b10}: lvl = 18;
+        {5'd18, 2'b10}: lvl = 20;
+        {5'd19, 2'b10}: lvl = 21;
+        {5'd20, 2'b10}: lvl = 23;
+        {5'd21, 2'b10}: lvl = 24;
+        {5'd22, 2'b10}: lvl = 25;
+        {5'd23, 2'b10}: lvl = 27;
+        {5'd24, 2'b10}: lvl = 29;
+        {5'd25, 2'b10}: lvl = 30;
+        {5'd26, 2'b10}: lvl = 32;
+        {5'd27, 2'b10}: lvl = 33;
+        {5'd28, 2'b10}: lvl = 34;
+        {5'd29, 2'b10}: lvl = 36;
+        {5'd30, 2'b10}: lvl = 37;
+        {5'd31, 2'b10}: lvl = 38;
+        // bright
+        {5'd00, 2'b11}: lvl = 17;
+        {5'd01, 2'b11}: lvl = 18;
+        {5'd02, 2'b11}: lvl = 20;
+        {5'd03, 2'b11}: lvl = 21;
+        {5'd04, 2'b11}: lvl = 23;
+        {5'd05, 2'b11}: lvl = 24;
+        {5'd06, 2'b11}: lvl = 25;
+        {5'd07, 2'b11}: lvl = 27;
+        {5'd08, 2'b11}: lvl = 29;
+        {5'd09, 2'b11}: lvl = 30;
+        {5'd10, 2'b11}: lvl = 32;
+        {5'd11, 2'b11}: lvl = 33;
+        {5'd12, 2'b11}: lvl = 34;
+        {5'd13, 2'b11}: lvl = 36;
+        {5'd14, 2'b11}: lvl = 37;
+        {5'd15, 2'b11}: lvl = 38;
+        {5'd16, 2'b11}: lvl = 42;
+        {5'd17, 2'b11}: lvl = 43;
+        {5'd18, 2'b11}: lvl = 45;
+        {5'd19, 2'b11}: lvl = 46;
+        {5'd20, 2'b11}: lvl = 47;
+        {5'd21, 2'b11}: lvl = 49;
+        {5'd22, 2'b11}: lvl = 50;
+        {5'd23, 2'b11}: lvl = 51;
+        {5'd24, 2'b11}: lvl = 54;
+        {5'd25, 2'b11}: lvl = 55;
+        {5'd26, 2'b11}: lvl = 56;
+        {5'd27, 2'b11}: lvl = 58;
+        {5'd28, 2'b11}: lvl = 59;
+        {5'd29, 2'b11}: lvl = 60;
+        {5'd30, 2'b11}: lvl = 62;
+        {5'd31, 2'b11}: lvl = 63;
+    endcase
+end
 
 endmodule


### PR DESCRIPTION
- The subpixels from jtshanon_coldac should arrive at the same phase. The time-divided version had the blue color registered one cen_pix sooner in the subsequent phases.
- Register and delay the tilemap and obj priority data by 2 pixels in the vdp/s16 video mixer, as in the original schematics.
