### PR TITLE
Fix Object RAM clearing for CPS. Issue #561

### DIFF
--- a/cores/cps1/hdl/jtcps1_sdram.v
+++ b/cores/cps1/hdl/jtcps1_sdram.v
@@ -257,6 +257,7 @@ jtcps1_prom_we #(
 jtframe_ram1_5slots #(
     .SDRAMW      ( 23            ),
     .SLOT0_ERASE (  1            ),
+    .SLOT0_ER_AW ( 20            ), // Erase 0x20_0000-0x2F_FFFF
     .SLOT0_AW    ( 17            ), // Main CPU RAM
     .SLOT0_DW    ( 16            ),
     .SLOT0_FASTWR(  0            ),

--- a/modules/jtframe/hdl/sdram/jtframe_ram1_5slots.v
+++ b/modules/jtframe/hdl/sdram/jtframe_ram1_5slots.v
@@ -18,11 +18,13 @@
 
 module jtframe_ram1_5slots #(parameter
     SDRAMW = 22,
-    SLOT0_ERASE  = 1, // erase memory contents after a reset
     SLOT0_FASTWR = 0,
 
     SLOT0_DW = 8, SLOT1_DW = 8, SLOT2_DW = 8, SLOT3_DW = 8, SLOT4_DW = 8,
     SLOT0_AW = 8, SLOT1_AW = 8, SLOT2_AW = 8, SLOT3_AW = 8, SLOT4_AW = 8,
+
+    SLOT0_ERASE  = 1, // erase memory contents after a reset
+    SLOT0_ER_AW  = SLOT0_AW, // erase width
 
     SLOT1_LATCH  = 0,
     SLOT2_LATCH  = 0,
@@ -124,7 +126,9 @@ assign slot2_ok = slot_ok[2];
 assign slot3_ok = slot_ok[3];
 assign slot4_ok = slot_ok[4];
 
-jtframe_ram_rq #(.SDRAMW(SDRAMW),.AW(SLOT0_AW),.DW(SLOT0_DW),.FASTWR(SLOT0_FASTWR),.ERASE(SLOT0_ERASE)) u_slot0(
+jtframe_ram_rq #(.SDRAMW(SDRAMW),.AW(SLOT0_AW),.DW(SLOT0_DW),.FASTWR(SLOT0_FASTWR),
+	.ERASE(SLOT0_ERASE), .ERASE_AW(SLOT0_ER_AW))
+u_slot0(
     .rst       ( rst                    ),
     .clk       ( clk                    ),
     .addr      ( slot0_addr             ),

--- a/modules/jtframe/hdl/sdram/jtframe_ram_rq.v
+++ b/modules/jtframe/hdl/sdram/jtframe_ram_rq.v
@@ -29,6 +29,7 @@ module jtframe_ram_rq #(parameter
     AW     = 18,
     DW     = 8,
     ERASE  = 1, // erase memory contents after a reset
+    ERASE_AW = AW,
     AUTOTOGGLE= // automatically toggles cs after a data delivery.
         `ifdef JTFRAME_SDRAM_TOGGLE
         1 `else 0 `endif ,
@@ -60,7 +61,7 @@ module jtframe_ram_rq #(parameter
     wire  [SDRAMW-1:0] size_ext   = { {SDRAMW-AW{1'b0}}, addr };
 
     reg          last_cs, pending, erased;
-    reg [AW-1:0] erase_cnt;
+    reg [ERASE_AW-1:0] erase_cnt;
     wire         cs_posedge = addr_ok && !last_cs;
     // wire   cs_negedge = !addr_ok && last_cs;
     assign erase_bsy = ERASE[0] && !erased;
@@ -85,7 +86,7 @@ module jtframe_ram_rq #(parameter
                     req        <= 1;
                     req_rnw    <= 0;
                     if(!req) begin
-                        sdram_addr <= { {SDRAMW-AW{1'b0}}, erase_cnt } + offset;
+                        sdram_addr <= { {SDRAMW-ERASE_AW{1'b0}}, erase_cnt } + offset;
                         {erased,erase_cnt}<= erase_cnt+1'd1;
                     end
                 end

--- a/modules/jtframe/hdl/sdram/jtframe_ramslot_ctrl.v
+++ b/modules/jtframe/hdl/sdram/jtframe_ramslot_ctrl.v
@@ -91,7 +91,7 @@ always @(posedge clk) begin
                         end else begin
                             sdram_addr  <= slot_addr_req[i*SDRAMW +: SDRAMW];
                             /* verilator lint_off WIDTH */
-                            sdram_wrmask<= wrmask>>(2*i); // ignore the warning in Quartus
+                            sdram_wrmask<= erase_bsy ? 2'b00 : wrmask>>(2*i); // ignore the warning in Quartus
                             /* verilator lint_on WIDTH */
                         end
                     end


### PR DESCRIPTION
-Add ERASE_AW to clear 0x200000-0x2FFFFF.
-SDRAM write mask was 2'b11 during erasing so it did not clear anything. 
-One small bug left: Last address is not written because erase_bsy goes low too early.