### PR TITLE
sync of sprites and shadows in xmen

### DIFF
--- a/cores/riders/hdl/jtriders_colmix.v
+++ b/cores/riders/hdl/jtriders_colmix.v
@@ -94,7 +94,7 @@ assign ci2       = xmen ? {lyrb_pxl[6:4],lyrb_pxl[11:10],lyrb_pxl[3:0]} : {2'd0,
 assign ci3       = xmen ?  lyrf_pxl : { 1'b0, lyrb_pxl[7:5], lyrb_pxl[3:0] };
 assign ci4       = xmen ?  8'd1 : { 1'b0, lyra_pxl[7:5], lyra_pxl[3:0] };
 assign shad      = xmen ? |shd_out : shd_out[0];
-assign shd_in    = xmen ?  shadow  : {1'b0,shadow[0]};
+assign shd_in    = xmen ?  xmen_sh : {1'b0,shadow[0]};
 
 always @* begin
     // LUT generated with
@@ -126,8 +126,12 @@ wire nodimming = !xmen;
 wire nodimming = 0;
 `endif
 
+reg [1:0] xmen_sh;
 always @(posedge clk) begin
-    if(pxl_cen) xmen_o <= {lyro_pri, lyro_pxl};
+    if(pxl_cen) begin
+        xmen_o  <= {lyro_pri, lyro_pxl};
+        xmen_sh <= ~shadow;
+    end
 end
 
 always @(posedge clk, posedge rst) begin


### PR DESCRIPTION
This fixes shadow and object not being synced in xmen.
Also, negating the shadow value that goes in the colmix fixes the colour of the images making shd_in. However, this makes shadow_in active low entering jtcolmix_053251 whereas measured in the pcb it appeared to be active high.
Maybe the signal should be negated after entering this module and not before? 

Before changes:
![frame_00002](https://github.com/user-attachments/assets/320632c7-58e4-4bc4-a7fb-84ca99002dea)

After:
![9](https://github.com/user-attachments/assets/3bb48a95-0667-45ca-987a-861488167b74)
