### PR TITLE
add NGPC+ display mode to NGPC core

### DIFF
--- a/cores/ngpc/cfg/mame2mra.toml
+++ b/cores/ngpc/cfg/mame2mra.toml
@@ -2,7 +2,7 @@
 sourcefile=[ "ngp.cpp" ]
 
 [Pocket]
-display_modes=[ 0x62 ]
+display_modes=[ 0x62, 0x63 ]
 
 [ROM]
 order = ["maincpu"]


### PR DESCRIPTION
Related to https://github.com/jotego/jtcores/issues/804

Display mode 0x62 (Original NGPC) was added in b89a709. This PR adds display mode 0x63 (Original NGPC+)
