### PR TITLE
Riders: brightness and shadow

### DIFF
--- a/cores/riders/hdl/jtriders_colmix.v
+++ b/cores/riders/hdl/jtriders_colmix.v
@@ -93,7 +93,7 @@ assign ci1       = xmen ?   xmen_o[8:0] : lyro_pxl[8:0];
 assign ci2       = xmen ? {lyrb_pxl[6:4],lyrb_pxl[11:10],lyrb_pxl[3:0]} : {2'd0, lyrf_pxl[7:5], lyrf_pxl[3:0] };
 assign ci3       = xmen ?  lyrf_pxl : { 1'b0, lyrb_pxl[7:5], lyrb_pxl[3:0] };
 assign ci4       = xmen ?  8'd1 : { 1'b0, lyra_pxl[7:5], lyra_pxl[3:0] };
-assign shad      = xmen ? |shd_out : shd_out[0];
+assign shad      = xmen ? |shd_out : ~shd_out[0];
 assign shd_in    = xmen ?  xmen_sh : {1'b0,shadow[0]};
 
 always @* begin

--- a/cores/riders/hdl/jtriders_obj.v
+++ b/cores/riders/hdl/jtriders_obj.v
@@ -112,7 +112,7 @@ assign cpu_din   = !objcha_n ? rmrd_addr[1] ? rom_data[31:16] : rom_data[15:0] :
 // 053244 (parodius) has 7 palette bits, top 2 used for priority
 assign pen15   = &pre_pxl[3:0];
 assign pen_eff = (pre_pxl[15:14]==0 || !pen15) ? pre_pxl[3:0] : 4'd0; // real color or 0 if shadow
-assign shd     =  pre_pxl[11] & pen15;
+assign shd     =  pre_pxl[14] & pen15;
 assign prio    =  {1'd1,pre_pxl[10:9],2'd0} ;
 assign pxl     = gfx_en[3] ? {pre_pxl[8:4], pen_eff} : 9'd0;
 

--- a/cores/simson/hdl/jtcolmix_053251.v
+++ b/cores/simson/hdl/jtcolmix_053251.v
@@ -136,7 +136,7 @@ always @(posedge clk, posedge rst) begin
             col_n   <= col4_n;
             cout    <= mix4;
             shd_out <= shd_sel ? ~shd_l : 2'b0;
-            brit    <= mix4p < ~mmr[5];
+            brit    <= mix4p >= mmr[5];
             // start pipeline
             st <= 0;
         end


### PR DESCRIPTION
The shadow information was completely lost in the original version for taking the wrong bit
The brit value was redefined after checking again the schematics

In this version, shadows that weren't drawn by the sprite are visible, for example:

Before:
![4](https://github.com/user-attachments/assets/421b2160-b871-4355-b9cf-dcd5da3f7bb1)

After:
![4](https://github.com/user-attachments/assets/2ae1d119-dd8f-4b96-9a11-072a73b2b7cc)