### PR TITLE
Faster reading of objects in xmen 

### DIFF
--- a/cores/riders/hdl/jt053244.sv
+++ b/cores/riders/hdl/jt053244.sv
@@ -304,6 +304,7 @@ jt053246_dma u_dma(
     .dma_trig   ( dma_trig  ),
     .k44_en     ( 1'b1      ),   // enable k053244/5 mode (default k053246/7)
     .simson     ( 1'b0      ),
+    .reversed   ( 1'b0      ),
 
     .hs         ( hs        ),
     .vs         ( vs        ),

--- a/cores/simson/hdl/jt053246.sv
+++ b/cores/simson/hdl/jt053246.sv
@@ -302,6 +302,7 @@ jt053246_dma u_dma(
     .dma_trig   ( 1'b0      ),
     .k44_en     ( 1'b0      ),   // enable k053244/5 mode (default k053246/7)
     .simson     ( simson    ),
+    .reversed   ( XMEN      ),
 
     .hs         ( hs        ),
     .vs         ( vs        ),

--- a/cores/simson/hdl/jt053246_dma.v
+++ b/cores/simson/hdl/jt053246_dma.v
@@ -26,6 +26,7 @@ module jt053246_dma(
     input             dma_trig,
     input             k44_en,   // enable k053244/5 mode (default k053246/7)
     input             simson,
+    input             reversed,
 
     input             hs,
     input             vs,
@@ -110,7 +111,7 @@ always @(posedge clk, posedge rst) begin
                 // I was skipping it before, but priority 0 is used in Vendetta and it must take priority
                 // over the rest (see scene vendetta/3)
                 // LUT half as big for 053244 and reversed order
-                dma_bufa <= { ~k44_en & dma_data[7], dma_data[6:0], 3'd0 };
+                dma_bufa <= { ~k44_en & dma_data[7], reversed ? -dma_data[6:0] : dma_data[6:0], 3'd0 };
                 dma_ok   <= dma_data[15] && (dma_data[7:0]!=0 || !simson);
             end
             dma_addr[12:1] <= dma_addr[12:1] + 1'd1;

--- a/cores/simson/hdl/jtsimson_obj.v
+++ b/cores/simson/hdl/jtsimson_obj.v
@@ -174,7 +174,7 @@ jt053246 #(.XMEN(XMEN))u_scan(    // sprite logic
 jtframe_objdraw #(
     .CW(16),.PW(4+10+2),.LATCH(1),.SWAPH(1),
     .ZW(12),.ZI(6),.ZENLARGE(1),
-    .FLIP_OFFSET(9'h12),.KEEP_OLD(1)
+    .FLIP_OFFSET(9'h12),.KEEP_OLD(!XMEN)
 ) u_draw(
     .rst        ( rst           ),
     .clk        ( clk           ),


### PR DESCRIPTION
Similar to what was done to fix #741, this fixes horizontal lines for #765

In Xmen, before:
![12](https://github.com/user-attachments/assets/f4c9d802-6c79-478f-877f-a73a0b6eb162)
After
![12](https://github.com/user-attachments/assets/b9826bd5-4c25-4b1b-8b34-24ce7861a305)

Since it's the same chip, I tried applying the same treatment in simson. It gives good results with The Simpsons (before/after):
![4](https://github.com/user-attachments/assets/26aac422-8b7e-4a26-86de-06190d786ce7)
![4](https://github.com/user-attachments/assets/780424fd-33e3-4093-8a6a-8ca2dc4322dc)
However, it doesn't work for Vendetta:
![frame_00002](https://github.com/user-attachments/assets/99bba8cd-a80a-4db8-8d05-2676cc423b6a)

As of now, this fix has only been seen in simulation. Still needs to be tested in the game