### PR TITLE
Correction of xoffset in xmen due to not registering obj-layer anymore

### DIFF
--- a/cores/simson/hdl/jt053246_scan.sv
+++ b/cores/simson/hdl/jt053246_scan.sv
@@ -89,7 +89,7 @@ assign {vsz,hsz} = size;
 always @(negedge clk) cen2 <= ~cen2;
 
 always @(posedge clk) begin
-    xadj <= xoffset - 10'd61;
+    xadj <= xoffset - 10'd62;
     yadj <= yoffset + (XMEN==1   ? 10'h107 :
                        simson    ? 10'h11f : 10'h10f); // Vendetta
     vscl <= rd_pzoffset(vzoom[9:0]);


### PR DESCRIPTION
Due to stop registering the obj-layer in the colmix, this gap appeared again (only the left half of Wolverine is drawn with the objects):
![17](https://github.com/user-attachments/assets/e4fd7911-40c8-4d95-9d10-e35d7316dc9b)
After correction:
![frame_00002](https://github.com/user-attachments/assets/4a5c2acc-1316-4f98-9c68-e78277f624c6)

This also worked for vendetta/scene 6, where the anchor and part of the ship are drawn by the objects and other layer at the same time and they were not in sync before
