### PR TITLE
Fix for sentinel's mouth on xmen

### DIFF
--- a/cores/simson/hdl/jt053246_scan.sv
+++ b/cores/simson/hdl/jt053246_scan.sv
@@ -64,7 +64,7 @@ parameter XMEN = 0;
 reg  [18:0] yz_add;
 reg  [11:0] vzoom;
 reg  [ 9:0] y, y2, x, ydiff, ydiff_b, xadj, yadj, x2;
-reg  [ 8:0] vlatch, ymove, vscl, hscl, hdump_r, hdump_diff;
+reg  [ 8:0] vlatch, ymove, vscl, hscl, hdump_r, hdump_min;
 reg  [ 7:0] scan_obj; // max 256 objects
 reg  [ 3:0] size;
 reg  [ 2:0] hstep, hcode, hsum, vsum;
@@ -124,8 +124,7 @@ always @* begin : B
     y2     = y + {1'b0,ymove};
     ydiff_b= y2 + { vlatch[8], vlatch } - 10'd8;
     ydiff  = yz_add[6+:10];
-    x2 = x - zmove( hsz, hscl ) - hdump_diff;
-    // x2 = x - zmove( hsz, hscl );
+    x2 = x - zmove( hsz, hscl ) - hdump_min;
     // test ver/game/scene/1 -> shadow, scan_obj 9
     case( vsz )
         0: vmir_eff = nx_mir[1] && !ydiff[3];
@@ -184,7 +183,7 @@ always @(posedge clk, posedge rst) begin : A
         hs_l <= hs;
         dr_start <= 0;
         hdump_r  <= hdump;
-        if( hdump < hdump_r ) hdump_diff <= hdump;
+        if( hdump < hdump_r ) hdump_min <= hdump;
         if( hs && !hs_l && vdump>9'h10D && vdump<9'h1f1) begin
             done     <= 0;
             scan_obj <= 0;

--- a/cores/simson/hdl/jt053246_scan.sv
+++ b/cores/simson/hdl/jt053246_scan.sv
@@ -63,8 +63,8 @@ parameter XMEN = 0;
 
 reg  [18:0] yz_add;
 reg  [11:0] vzoom;
-reg  [ 9:0] y, y2, x, ydiff, ydiff_b, xadj, yadj;
-reg  [ 8:0] vlatch, ymove, vscl, hscl;
+reg  [ 9:0] y, y2, x, ydiff, ydiff_b, xadj, yadj, x2;
+reg  [ 8:0] vlatch, ymove, vscl, hscl, hdump_r, hdump_diff;
 reg  [ 7:0] scan_obj; // max 256 objects
 reg  [ 3:0] size;
 reg  [ 2:0] hstep, hcode, hsum, vsum;
@@ -124,6 +124,8 @@ always @* begin : B
     y2     = y + {1'b0,ymove};
     ydiff_b= y2 + { vlatch[8], vlatch } - 10'd8;
     ydiff  = yz_add[6+:10];
+    x2 = x - zmove( hsz, hscl ) - hdump_diff;
+    // x2 = x - zmove( hsz, hscl );
     // test ver/game/scene/1 -> shadow, scan_obj 9
     case( vsz )
         0: vmir_eff = nx_mir[1] && !ydiff[3];
@@ -181,6 +183,8 @@ always @(posedge clk, posedge rst) begin : A
     end else if( cen2 ) begin
         hs_l <= hs;
         dr_start <= 0;
+        hdump_r  <= hdump;
+        if( hdump < hdump_r ) hdump_diff <= hdump;
         if( hs && !hs_l && vdump>9'h10D && vdump<9'h1f1) begin
             done     <= 0;
             scan_obj <= 0;
@@ -240,7 +244,7 @@ always @(posedge clk, posedge rst) begin : A
                     if( (!dr_start && !dr_busy) || !inzone ) begin
                         {code[4],code[2],code[0]} <= hcode + hsum;
                         if( hstep==0 ) begin
-                            hpos    <= x - zmove( hsz, hscl );
+                            hpos    <= x - zmove( hsz, hscl ) + {6'b0, x2[9], 3'b0};
                         end else begin
                             hpos    <= hpos + 10'h10;
                             hz_keep <= 1;

--- a/cores/simson/hdl/jt053246_scan.sv
+++ b/cores/simson/hdl/jt053246_scan.sv
@@ -61,17 +61,20 @@ module jt053246_scan (    // sprite logic
 );
 parameter XMEN = 0;
 
+localparam [9:0] HDUMP_MIN = 10'h020,
+                 HADJ      = 10'h008;
+
 reg  [18:0] yz_add;
 reg  [11:0] vzoom;
 reg  [ 9:0] y, y2, x, ydiff, ydiff_b, xadj, yadj, x2;
-reg  [ 8:0] vlatch, ymove, vscl, hscl, hdump_r, hdump_min;
+reg  [ 8:0] vlatch, ymove, vscl, hscl;
 reg  [ 7:0] scan_obj; // max 256 objects
 reg  [ 3:0] size;
 reg  [ 2:0] hstep, hcode, hsum, vsum;
 reg  [ 1:0] scan_sub, reserved;
 reg         inzone, hs_l, done, hdone,
             vmir, hmir, sq, pre_vf, pre_hf, indr,
-            hmir_eff, vmir_eff, hhalf;
+            hmir_eff, vmir_eff, hhalf, left_wrap;
 
 wire [ 1:0] nx_mir, hsz, vsz;
 wire        last_obj;
@@ -120,11 +123,12 @@ function [8:0] rd_pzoffset( input [9:0] zoom );
 endfunction 
 
 always @* begin : B
-    ymove  = zmove( vsz, vscl );
-    y2     = y + {1'b0,ymove};
-    ydiff_b= y2 + { vlatch[8], vlatch } - 10'd8;
-    ydiff  = yz_add[6+:10];
-    x2 = x - zmove( hsz, hscl ) - hdump_min;
+    ymove     = zmove( vsz, vscl );
+    y2        = y + {1'b0,ymove};
+    ydiff_b   = y2 + { vlatch[8], vlatch } - 10'd8;
+    ydiff     = yz_add[6+:10];
+    x2        = x - zmove( hsz, hscl );
+    left_wrap = x2 < HDUMP_MIN;
     // test ver/game/scene/1 -> shadow, scan_obj 9
     case( vsz )
         0: vmir_eff = nx_mir[1] && !ydiff[3];
@@ -182,8 +186,6 @@ always @(posedge clk, posedge rst) begin : A
     end else if( cen2 ) begin
         hs_l <= hs;
         dr_start <= 0;
-        hdump_r  <= hdump;
-        if( hdump < hdump_r ) hdump_min <= hdump;
         if( hs && !hs_l && vdump>9'h10D && vdump<9'h1f1) begin
             done     <= 0;
             scan_obj <= 0;
@@ -243,7 +245,7 @@ always @(posedge clk, posedge rst) begin : A
                     if( (!dr_start && !dr_busy) || !inzone ) begin
                         {code[4],code[2],code[0]} <= hcode + hsum;
                         if( hstep==0 ) begin
-                            hpos    <= x - zmove( hsz, hscl ) + {6'b0, x2[9], 3'b0};
+                            hpos    <= x2 + (left_wrap ? HADJ : 10'b0 );
                         end else begin
                             hpos    <= hpos + 10'h10;
                             hz_keep <= 1;


### PR DESCRIPTION
This change checks if the sprite starts being drawn so much to the left that it actually starts at the right end and, if so, adds a correction in the starting point.

This fixes the sentinel mouth not being correctly aligned(#765 ):
![10](https://github.com/user-attachments/assets/d07de4dc-c9e2-4e92-821b-63ba603581db)
