### PR TITLE
K46: Removed unused zoom bits

### DIFF
--- a/cores/simson/hdl/jt053246.sv
+++ b/cores/simson/hdl/jt053246.sv
@@ -48,7 +48,7 @@ module jt053246(    // sprite logic
     output reg        vflip,
     output reg [ 9:0] hpos,
     output     [ 3:0] ysub,
-    output reg [11:0] hzoom,
+    output reg [ 9:0] hzoom,
     output reg        hz_keep,
 
     // base video

--- a/cores/simson/hdl/jt053246_scan.sv
+++ b/cores/simson/hdl/jt053246_scan.sv
@@ -31,7 +31,7 @@ module jt053246_scan (    // sprite logic
     output reg        vflip,
     output reg [ 9:0] hpos,
     output     [ 3:0] ysub,
-    output reg [11:0] hzoom,
+    output reg [ 9:0] hzoom,
     output reg        hz_keep,
 
     // base video
@@ -65,8 +65,7 @@ localparam [9:0] HDUMP_MIN = 10'h020,
                  HADJ      = 10'h008;
 
 reg  [18:0] yz_add;
-reg  [11:0] vzoom;
-reg  [ 9:0] y, y2, x, ydiff, ydiff_b, xadj, yadj, x2;
+reg  [ 9:0] y, y2, vzoom, x, ydiff, ydiff_b, xadj, yadj, x2;
 reg  [ 8:0] vlatch, ymove, vscl, hscl;
 reg  [ 7:0] scan_obj; // max 256 objects
 reg  [ 3:0] size;
@@ -95,10 +94,10 @@ always @(posedge clk) begin
     xadj <= xoffset - 10'd62;
     yadj <= yoffset + (XMEN==1   ? 10'h107 :
                        simson    ? 10'h11f : 10'h10f); // Vendetta
-    vscl <= rd_pzoffset(vzoom[9:0]);
-    hscl <= rd_pzoffset(hzoom[9:0]);
+    vscl <= rd_pzoffset(vzoom);
+    hscl <= rd_pzoffset(hzoom);
     /* verilator lint_off WIDTH */
-    yz_add  <= vzoom[9:0]*ydiff_b; // vzoom < 10'h40 enlarge, >10'h40 reduce
+    yz_add  <= vzoom*ydiff_b; // vzoom < 10'h40 enlarge, >10'h40 reduce
                                    // opposite to the one in Aliens, which always
                                    // shrunk for non-zero zoom values
     /* verilator lint_on WIDTH */
@@ -217,8 +216,8 @@ always @(posedge clk, posedge rst) begin : A
                 2: begin
                     x <= x-xadj;
                     y <= y+yadj;
-                    vzoom <= {2'b0, scan_even[9:0]};
-                    hzoom <= sq ? {2'b0, scan_even[9:0]} : {2'b0, scan_odd[9:0]};
+                    vzoom <= scan_even[9:0];
+                    hzoom <= sq ? scan_even[9:0] : scan_odd[9:0];
                 end
                 3: begin
                     { vmir, hmir } <= nx_mir;

--- a/cores/simson/hdl/jtsimson_obj.v
+++ b/cores/simson/hdl/jtsimson_obj.v
@@ -82,9 +82,8 @@ wire        dr_start, dr_busy;
 wire [15:0] code;
 wire [ 9:0] attr;     // OC pins
 wire        hflip, vflip, hz_keep, pre_cs;
-wire [ 9:0] hpos;
+wire [ 9:0] hpos, hzoom;
 wire [ 3:0] ysub;
-wire [11:0] hzoom;
 wire [31:0] sorted;
 wire        pen15;
 
@@ -190,7 +189,7 @@ jtframe_objdraw #(
     .xpos       ( hpos          ),
     .ysub       ( ysub          ),
     .hz_keep    ( hz_keep       ),
-    .hzoom      ( hzoom         ),
+    .hzoom      ( {2'b0,hzoom}  ),
 
     .hflip      ( ~hflip        ),
     .vflip      ( vflip         ),

--- a/cores/simson/hdl/jtsimson_obj.v
+++ b/cores/simson/hdl/jtsimson_obj.v
@@ -172,7 +172,7 @@ jt053246 #(.XMEN(XMEN))u_scan(    // sprite logic
 
 jtframe_objdraw #(
     .AW(10),.CW(16),.PW(4+10+2),.LATCH(1),.SWAPH(1),
-    .ZW(12),.ZI(6),.ZENLARGE(1),
+    .ZW(10),.ZI(6),.ZENLARGE(1),
     .FLIP_OFFSET(9'h12),.KEEP_OLD(1)
 ) u_draw(
     .rst        ( rst           ),
@@ -189,7 +189,7 @@ jtframe_objdraw #(
     .xpos       ( hpos          ),
     .ysub       ( ysub          ),
     .hz_keep    ( hz_keep       ),
-    .hzoom      ( {2'b0,hzoom}  ),
+    .hzoom      ( hzoom         ),
 
     .hflip      ( ~hflip        ),
     .vflip      ( vflip         ),


### PR DESCRIPTION
Removed unused bits to simplify zoom values in k46