### PR TITLE
Faster reading by reversing order also applied to Vendetta

### DIFF
--- a/cores/riders/hdl/jt053244.sv
+++ b/cores/riders/hdl/jt053244.sv
@@ -128,7 +128,6 @@ jt053246_dma u_dma(
     .dma_trig   ( dma_trig  ),
     .k44_en     ( 1'b1      ),   // enable k053244/5 mode (default k053246/7)
     .simson     ( 1'b0      ),
-    .reversed   ( 1'b0      ),
 
     .hs         ( hs        ),
     .vs         ( vs        ),

--- a/cores/simson/hdl/jt053246.sv
+++ b/cores/simson/hdl/jt053246.sv
@@ -131,7 +131,6 @@ jt053246_dma u_dma(
     .dma_trig   ( 1'b0      ),
     .k44_en     ( 1'b0      ),   // enable k053244/5 mode (default k053246/7)
     .simson     ( simson    ),
-    .reversed   ( XMEN      ),
 
     .hs         ( hs        ),
     .vs         ( vs        ),

--- a/cores/simson/hdl/jt053246_dma.v
+++ b/cores/simson/hdl/jt053246_dma.v
@@ -26,7 +26,6 @@ module jt053246_dma(
     input             dma_trig,
     input             k44_en,   // enable k053244/5 mode (default k053246/7)
     input             simson,
-    input             reversed,
 
     input             hs,
     input             vs,
@@ -111,7 +110,7 @@ always @(posedge clk, posedge rst) begin
                 // I was skipping it before, but priority 0 is used in Vendetta and it must take priority
                 // over the rest (see scene vendetta/3)
                 // LUT half as big for 053244 and reversed order
-                dma_bufa <= { ~k44_en & dma_data[7], reversed ? -dma_data[6:0] : dma_data[6:0], 3'd0 };
+                dma_bufa <= { ~k44_en & dma_data[7], k44_en ? dma_data[6:0] : ~dma_data[6:0], 3'd0 };
                 dma_ok   <= dma_data[15] && (dma_data[7:0]!=0 || !simson);
             end
             dma_addr[12:1] <= dma_addr[12:1] + 1'd1;

--- a/cores/simson/hdl/jt053246_scan.sv
+++ b/cores/simson/hdl/jt053246_scan.sv
@@ -68,7 +68,7 @@ reg  [18:0] yz_add;
 reg  [11:0] vzoom;
 reg  [ 9:0] y, y2, x, ydiff, ydiff_b, xadj, yadj, x2;
 reg  [ 8:0] vlatch, ymove, vscl, hscl;
-reg  [ 7:0] scan_obj; // max 256 objects
+reg  [ 7:0] scan_obj/*, zcode*/; // max 256 objects
 reg  [ 3:0] size;
 reg  [ 2:0] hstep, hcode, hsum, vsum;
 reg  [ 1:0] scan_sub, reserved;
@@ -198,6 +198,7 @@ always @(posedge clk, posedge rst) begin : A
                 0: begin
                     hhalf <= 0;
                     { sq, pre_vf, pre_hf, size } <= scan_even[14:8];
+                    // zcode   <= scan_even[7:0];
                     code    <= scan_odd;
                     hstep   <= 0;
                     hz_keep <= 0;

--- a/cores/simson/hdl/jtsimson_obj.v
+++ b/cores/simson/hdl/jtsimson_obj.v
@@ -172,9 +172,9 @@ jt053246 #(.XMEN(XMEN))u_scan(    // sprite logic
 );
 
 jtframe_objdraw #(
-    .AW(10),.CW(16),.PW(4+10+2),.LATCH(1),.SWAPH(1),`ifdef XMEN .SHADOW_PEN (4'd15), `endif
-    .ZW(12),.ZI(6),.ZENLARGE(1),.SHADOW(XMEN),.SW(2),
-    .FLIP_OFFSET(9'h12),.KEEP_OLD(0)
+    `ifdef XMEN .SHADOW(1),.SHADOW_PEN (4'd15), `endif
+    .AW(10),.CW(16),.PW(4+10+2),.LATCH(1),.SWAPH(1),
+    .ZW(12),.ZI(6),.ZENLARGE(1),.SW(2),.FLIP_OFFSET(9'h12)
 ) u_draw(
     .rst        ( rst           ),
     .clk        ( clk           ),

--- a/cores/simson/hdl/jtsimson_obj.v
+++ b/cores/simson/hdl/jtsimson_obj.v
@@ -172,7 +172,7 @@ jt053246 #(.XMEN(XMEN))u_scan(    // sprite logic
 );
 
 jtframe_objdraw #(
-    .AW(10),.CW(16),.PW(4+10+2),.LATCH(1),.SWAPH(1),.SHADOW_PEN (4'd15),
+    .AW(10),.CW(16),.PW(4+10+2),.LATCH(1),.SWAPH(1),`ifdef XMEN .SHADOW_PEN (4'd15), `endif
     .ZW(12),.ZI(6),.ZENLARGE(1),.SHADOW(XMEN),.SW(2),
     .FLIP_OFFSET(9'h12),.KEEP_OLD(0)
 ) u_draw(

--- a/cores/simson/hdl/jtsimson_obj.v
+++ b/cores/simson/hdl/jtsimson_obj.v
@@ -173,8 +173,8 @@ jt053246 #(.XMEN(XMEN))u_scan(    // sprite logic
 
 jtframe_objdraw #(
     .AW(10),.CW(16),.PW(4+10+2),.LATCH(1),.SWAPH(1),.SHADOW_PEN (4'd15),
-    .ZW(12),.ZI(6),.ZENLARGE(1),.SHADOW(1),.SW(2),
-    .FLIP_OFFSET(9'h12),.KEEP_OLD(!XMEN)
+    .ZW(12),.ZI(6),.ZENLARGE(1),.SHADOW(XMEN),.SW(2),
+    .FLIP_OFFSET(9'h12),.KEEP_OLD(0)
 ) u_draw(
     .rst        ( rst           ),
     .clk        ( clk           ),

--- a/modules/jtframe/hdl/ram/jtframe_obj_buffer.v
+++ b/modules/jtframe/hdl/ram/jtframe_obj_buffer.v
@@ -59,7 +59,6 @@ module jtframe_obj_buffer #(parameter
 );
 
 localparam EW = SHADOW==1 ? DW-SW : DW;
-localparam SHD_PEN = SHADOW==1 ? SHADOW_PEN : ALPHA;
 
 reg     line, last_LHBL;
 wire    new_we;
@@ -72,10 +71,10 @@ wire [EW-1:0]       old;
 
 assign new_we = wr_data[ALPHAW-1:0] != ALPHA[ALPHAW-1:0] && we
     && ((old[ALPHAW-1:0]==ALPHA[ALPHAW-1:0]  /*||
-         (old[ALPHAW-1:0]==SHD_PEN[ALPHAW-1:0] && SHD_PEN!=ALPHA && wr_data[ALPHAW-1:0]!=SHD_PEN[ALPHAW-1:0] )*/
+         (old[ALPHAW-1:0]==SHADOW_PEN[ALPHAW-1:0] && SHADOW_PEN!=ALPHA && wr_data[ALPHAW-1:0]!=SHADOW_PEN[ALPHAW-1:0] )*/
          ) || (KEEP_OLD==0 &&
-           ( wr_data[ALPHAW-1:0] != SHD_PEN[ALPHAW-1:0] || old[ALPHAW-1:0]==SHD_PEN[ALPHAW-1:0]
-            || SHD_PEN==ALPHA )));
+           ( (wr_data[ALPHAW-1:0] != SHADOW_PEN[ALPHAW-1:0] || old[ALPHAW-1:0]==SHADOW_PEN[ALPHAW-1:0]) && SHADOW==1
+            || SHADOW==0 )));
 
 
 `ifdef SIMULATION

--- a/modules/jtframe/hdl/ram/jtframe_obj_buffer.v
+++ b/modules/jtframe/hdl/ram/jtframe_obj_buffer.v
@@ -59,6 +59,7 @@ module jtframe_obj_buffer #(parameter
 );
 
 localparam EW = SHADOW==1 ? DW-SW : DW;
+localparam SHD_PEN = SHADOW==1 ? SHADOW_PEN : ALPHA;
 
 reg     line, last_LHBL;
 wire    new_we;
@@ -71,10 +72,10 @@ wire [EW-1:0]       old;
 
 assign new_we = wr_data[ALPHAW-1:0] != ALPHA[ALPHAW-1:0] && we
     && ((old[ALPHAW-1:0]==ALPHA[ALPHAW-1:0]  /*||
-         (old[ALPHAW-1:0]==SHADOW_PEN[ALPHAW-1:0] && SHADOW_PEN!=ALPHA && wr_data[ALPHAW-1:0]!=SHADOW_PEN[ALPHAW-1:0] )*/
+         (old[ALPHAW-1:0]==SHD_PEN[ALPHAW-1:0] && SHD_PEN!=ALPHA && wr_data[ALPHAW-1:0]!=SHD_PEN[ALPHAW-1:0] )*/
          ) || (KEEP_OLD==0 &&
-           ( wr_data[ALPHAW-1:0] != SHADOW_PEN[ALPHAW-1:0] || old[ALPHAW-1:0]==SHADOW_PEN[ALPHAW-1:0]
-            || SHADOW_PEN==ALPHA )));
+           ( wr_data[ALPHAW-1:0] != SHD_PEN[ALPHAW-1:0] || old[ALPHAW-1:0]==SHD_PEN[ALPHAW-1:0]
+            || SHD_PEN==ALPHA )));
 
 
 `ifdef SIMULATION


### PR DESCRIPTION
Managed to ensure Keep_old==0 in both simson and xmen

Reversing the order had to be made using ~ instead of -, due to priority 0 being used.
When trying to reverse the order using -, the object 0 (which previously was drawn before all other objects and never overwritten) was being overwritten due to still being drawn first, instead of last, for -0 remains unchanged. Applying ~, 0 becomes F, which would come last instead of first, overwritting everything else

SHADOW==0 had to be used in simson because Vendetta uses the shadow pen to write black pixels. With the applied conditions, in the obj buffer, these black pixels could not be drawn over something else

This change slightly helps with #841 but does not fix it completely yet:
![31](https://github.com/user-attachments/assets/4e433a74-d9ef-4992-8dfc-b1bd032a8ecd)
![32](https://github.com/user-attachments/assets/bcaed8c8-5f4a-428e-874b-62fb6a3c895e)
