### PR TITLE
Fixes #832 and some shadow issues in xmen (#765)

### DIFF
--- a/cores/riders/hdl/jtriders_colmix.v
+++ b/cores/riders/hdl/jtriders_colmix.v
@@ -91,7 +91,7 @@ assign ci2       = {2'd0, lyrf_pxl[7:5], lyrf_pxl[3:0] };
 assign ci3       = {1'b0, lyrb_pxl[7:5], lyrb_pxl[3:0] };
 assign ci4       = {1'b0, lyra_pxl[7:5], lyra_pxl[3:0] };
 assign shad      =  shd_out[0];
-assign shd_in    = ~{1'b0,shadow};
+assign shd_in    = {1'b0,shadow};
 
 always @* begin
     // LUT generated with

--- a/cores/riders/hdl/jtriders_colmix.v
+++ b/cores/riders/hdl/jtriders_colmix.v
@@ -90,8 +90,8 @@ assign ci1       =  lyro_pxl[8:0];
 assign ci2       = {2'd0, lyrf_pxl[7:5], lyrf_pxl[3:0] };
 assign ci3       = {1'b0, lyrb_pxl[7:5], lyrb_pxl[3:0] };
 assign ci4       = {1'b0, lyra_pxl[7:5], lyra_pxl[3:0] };
-assign shad      = ~shd_out[0];
-assign shd_in    = {1'b0,shadow};
+assign shad      =  shd_out[0];
+assign shd_in    = ~{1'b0,shadow};
 
 always @* begin
     // LUT generated with

--- a/cores/simson/hdl/jtcolmix_053251.v
+++ b/cores/simson/hdl/jtcolmix_053251.v
@@ -131,7 +131,7 @@ always @(posedge clk, posedge rst) begin
             pri4_mux <= op[4] ? 6'h3f :                  mmr[4]        ;
             pre_n <= op;
             cl0   <= ci0; cl1 <= ci1; cl2 <= ci2; cl3 <= ci3; cl4 <= ci4;
-            shd_l <= shd_in;
+            shd_l <= ~shd_in;
             // assign module outputs
             col_n   <= col4_n;
             cout    <= mix4;

--- a/cores/simson/hdl/jtcolmix_053251.v
+++ b/cores/simson/hdl/jtcolmix_053251.v
@@ -162,7 +162,7 @@ always @(posedge clk, posedge rst) begin
                 col4_n<= l4 ? pre_n[4] : col3_n;
             end
             5: begin
-                shd_sel <= mix4p < shd_p;
+                shd_sel <= shd_p < mix4p;
             end
             default:;
         endcase

--- a/cores/simson/hdl/jtsimson_colmix.v
+++ b/cores/simson/hdl/jtsimson_colmix.v
@@ -68,12 +68,12 @@ assign {blue,green,red} = (lvbl & lhbl ) ? bgr : 24'd0;
 assign ioctl_din = pal_dout;
 
 function [23:0] dim( input [14:0] cin, input shade );
-    dim = !shade? {   1'b0, cin[14:10], cin[14:13],    // dim
-                      1'b0, cin[ 9: 5], cin[ 9: 8],
-                      1'b0, cin[ 4: 0], cin[ 4: 3] } :
-                  {         cin[14:10], cin[14:12],    // do not dim
+    dim = !shade? {     cin[14:10], cin[14:12],    // do not dim
                             cin[ 9: 5], cin[ 9: 7],
-                            cin[ 4: 0], cin[ 4: 2] };
+                            cin[ 4: 0], cin[ 4: 2] } :
+                  {   1'b0, cin[14:10], cin[14:13],    // dim
+                      1'b0, cin[ 9: 5], cin[ 9: 8],
+                      1'b0, cin[ 4: 0], cin[ 4: 3] } ;
 endfunction
 
 always @(posedge clk) begin

--- a/cores/simson/hdl/jtsimson_obj.v
+++ b/cores/simson/hdl/jtsimson_obj.v
@@ -110,7 +110,7 @@ assign cpu_din   = !objcha_n ? rmrd_addr[1] ? rom_data[31:16] : rom_data[15:0] :
 // 053244 (parodius) has 7 palette bits, top 2 used for priority
 assign pen15   = &pre_pxl[3:0];
 assign pen_eff = (pre_pxl[15:14]==0 || !pen15) ? pre_pxl[3:0] : 4'd0; // real color or 0 if shadow
-assign shd     =  pre_pxl[15:14] & {2{pen15}};
+assign shd     =  ~(pre_pxl[15:14] & {2{pen15}});
 assign prio    =  pre_pxl[13:9];
 assign pxl     = gfx_en[3] ? {pre_pxl[8:4], pen_eff} : 9'd0;
 

--- a/cores/tmnt/hdl/jttmnt_colmix.v
+++ b/cores/tmnt/hdl/jttmnt_colmix.v
@@ -138,7 +138,7 @@ always @(posedge clk) begin
         shl      <= 0;
     end else begin
         if( pxl_cen ) begin
-            shl <= k251_en ? k251_shd[0] : shad;
+            shl <= k251_en ? ~k251_shd[0] : shad;
             bgr <= dim( pal_dout[14:0], shl);
         end
     end
@@ -175,7 +175,7 @@ jtcolmix_053251 u_k251(
     .ci4        ( { 1'b0, lyra_pxl[7:5], lyra_pxl[3:0] } ),
     .ci3        ( { 1'b0, lyrb_pxl[7:5], lyrb_pxl[3:0] } ),
     // shadow
-    .shd_in     ({1'b0,shadow}),
+    .shd_in     (~{1'b0,shadow}),
     .shd_out    ( k251_shd  ),
     // dump to SD card
     .ioctl_addr ( ioctl_ram ? ioctl_addr[3:0] : debug_bus[3:0] ),

--- a/cores/tmnt/hdl/jttmnt_colmix.v
+++ b/cores/tmnt/hdl/jttmnt_colmix.v
@@ -175,7 +175,7 @@ jtcolmix_053251 u_k251(
     .ci4        ( { 1'b0, lyra_pxl[7:5], lyra_pxl[3:0] } ),
     .ci3        ( { 1'b0, lyrb_pxl[7:5], lyrb_pxl[3:0] } ),
     // shadow
-    .shd_in     (~{1'b0,shadow}),
+    .shd_in     ({1'b0,shadow}),
     .shd_out    ( k251_shd  ),
     // dump to SD card
     .ioctl_addr ( ioctl_ram ? ioctl_addr[3:0] : debug_bus[3:0] ),

--- a/cores/xmen/hdl/jtxmen_colmix.v
+++ b/cores/xmen/hdl/jtxmen_colmix.v
@@ -86,7 +86,7 @@ assign ci2       = {lyrb_pxl[6:4],lyrb_pxl[11:10],lyrb_pxl[3:0]};
 assign ci3       =  lyrf_pxl ;
 assign ci4       =  8'd1;
 assign shad      = |shd_out;
-assign shd_in    = ~shadow;
+assign shd_in    =  shadow;
 
 function [7:0] conv58(input [4:0] cin );
 begin


### PR DESCRIPTION
Shadow priority in colmix k053251 better matching schematic logic. 

Sky and Konami logo colors are correct in The Simpsons:
![14](https://github.com/user-attachments/assets/f21b9cf9-10b1-441c-b7fd-dd4d0cfecde8)
![33](https://github.com/user-attachments/assets/fc841f69-cfcd-4a1b-9a3f-6a6d2d9fb5f3)

Also, fixes shadows disappearing and shadow layer problems in Xmen:
 
![15](https://github.com/user-attachments/assets/0881777b-4bd4-491a-aef4-d9aacf114ca1)
![13](https://github.com/user-attachments/assets/7efcc000-5375-4d97-8448-54c9fd4f1c38)
