### PR TITLE
Changed horizontal mirror logic in k44. Fixes #851

### DIFF
--- a/cores/riders/hdl/jt053244_scan.sv
+++ b/cores/riders/hdl/jt053244_scan.sv
@@ -74,7 +74,7 @@ reg  [ 8:0] zoffset [0:255];
 reg  [ 3:0] pzoffset[0:15 ];
 reg  [ 6:0] pri;
 
-assign hflip     = ghf ^ pre_hf ^ hmir_eff;
+assign hflip     = (ghf ^ pre_hf)&!hmir | hmir_eff;
 assign scan_addr = { scan_obj, scan_sub };
 assign ysub      = ydiff[3:0];
 assign last_obj  = &scan_obj[6:0];


### PR DESCRIPTION
Compared the mirror logic we had for k44 (`ghf ^ pre_hf ^ hmir_eff` ) with the one in Mame. 

Both tables of truth were slightly different, so I added a small change. The pre_hflip is influenced by the horizontal mirroring, but not the other way, and that was causing the problem in #851. This commit fixes #851 
![32](https://github.com/user-attachments/assets/c09dfd7f-32ca-4500-afd3-36b802a84d7c)

Maybe a similar approach with the vertical flip might help with #724, but I need to check it more thoroughly. I tried changing vflip definition in the same way and the scenes stayed the same