### PR TITLE
Paroda: blue bell explosion fix

### DIFF
--- a/cores/riders/hdl/jt053244_scan.sv
+++ b/cores/riders/hdl/jt053244_scan.sv
@@ -87,7 +87,6 @@ always @(negedge clk) cen2 <= ~cen2;
 always @(posedge clk) begin
     xadj <= xoffset + 10'h66 ;
     yadj <= yoffset + 10'h107;
-    vscl <= rd_pzoffset(vzoom);
     hscl <= rd_pzoffset(hzoom);
     /* verilator lint_off WIDTH */
     yz_add  <= vzoom[9:0]*ydiff_b; // vzoom < 10'h40 enlarge, >10'h40 reduce
@@ -123,10 +122,10 @@ always @* begin
     ydiff  = yz_add[6+:10];
     // test ver/parodius/scene/9 -> "bomb", scan_obj 5
     case( vsz )
-        0: vmir_eff = nx_mir[1] && ydiff[3];
-        1: vmir_eff = nx_mir[1] && ydiff[4];
-        2: vmir_eff = nx_mir[1] && ydiff[5];
-        3: vmir_eff = nx_mir[1] && ydiff[6];
+        0: vmir_eff = nx_mir[1] && ydiff[3] && ydiff[9:4]==0;
+        1: vmir_eff = nx_mir[1] && ydiff[4] && ydiff[9:5]==0;
+        2: vmir_eff = nx_mir[1] && ydiff[5] && ydiff[9:6]==0;
+        3: vmir_eff = nx_mir[1] && ydiff[6] && ydiff[9:7]==0;
     endcase
     hmir_eff = hmir & hhalf;
     case( vsz )
@@ -212,6 +211,7 @@ always @(posedge clk, posedge rst) begin
                     y <=  y+yadj;
                     vzoom <= scan_even[11:0];
                     hzoom <= sq ? scan_even[11:0] : scan_odd[11:0];
+                    vscl <= rd_pzoffset(scan_even[11:0]);
                 end
                 3: begin
                     { vmir, hmir } <= nx_mir;


### PR DESCRIPTION
This change fixes #724 . Some scenes where the extra pieces of the explosion cannot be seen anymore(before/after):
Scene 26
![frame_00002](https://github.com/user-attachments/assets/30c1f9fe-b013-4ac7-a97c-d01b625aa342)
![26](https://github.com/user-attachments/assets/8918abcf-0153-4d1d-b7ec-5b32f5503a03)
Scene 28
![frame_00002](https://github.com/user-attachments/assets/657b1971-584e-4ac0-a83c-491ec0711616)
![28](https://github.com/user-attachments/assets/ee7446a2-0bd1-4601-a16b-eeafb043d31b)

When the explosion is triggered close to the bottom/top of the screen, something similar can be seen coming from the top of the screen when the explosion is at its biggest, crossing from one border of the screen to the other. However, this effect can also be found in the PCB for this circumstance:
![34](https://github.com/user-attachments/assets/c0cae3d4-f7cb-4df4-b74c-b68c5780b134)

To fix it, corrected vmir_eff evaluation, being more restrictive with the conditions and moved vscl definition to the states machine. Right after registering vzoom (state 2), calculation of the correct vscl took one more clock cycle, if vzoom remained the same, there should be no problem in state 3 for calculating vflip. However, if it did change drastically, like in the case of the explosion, time wasn't enough to include the correct y_diff into vmir_eff, and therefore, vflip would be wrong 