### PR TITLE
Removed horizontal delay in jtframe_tilemap when flip==1

### DIFF
--- a/modules/jtframe/hdl/video/jtframe_tilemap.v
+++ b/modules/jtframe/hdl/video/jtframe_tilemap.v
@@ -83,7 +83,6 @@ assign veff = FLIP_VDUMP ? vdump ^ { FLIP_MSB[0]&flip, {8{flip}}} : vdump;
 always @* begin
     hoff = hdump - HDUMP_OFFSET[8:0];
     heff = FLIP_HDUMP ? hoff ^ {9{flip}} : hoff;
-    if( flip ) heff = heff - 9'd7;
 end
 
 initial begin


### PR DESCRIPTION
It seems that this condition became reduntant from 10c77a37a1a5a55e9569e3250bfb6e538a81312b and on.

The characters/letters layer in 1942 is drawn with this module, so, when flip==1, this layer got out of the center that the rest of the layers had, as it could be seen by the top text of 1942 and Vulgus being found at the bottom (#858 , #844 )
![image](https://github.com/user-attachments/assets/3cb99023-9402-4f7e-9161-a228f9db332b)

This change fixes #858 and #844

![frame_00012](https://github.com/user-attachments/assets/9c904652-70bb-41a1-8a3e-945bb511c60b)
![frame_00038](https://github.com/user-attachments/assets/c05f9b5b-b31e-4c88-a311-ec07cfe11acd)
