### PR TITLE
Detection of DIP switches in Moonwalker to enable 3-player game

### DIFF
--- a/cores/s18/cfg/mame2mra.toml
+++ b/cores/s18/cfg/mame2mra.toml
@@ -61,7 +61,9 @@ data = [
     { offset=0x14, setnames=["astorm3","astormu"], data="01" },
 
     # 5874 board
-    { machines=["astorm", "bloxeed", "mwalk", "pontoon"],  offset=0x18, data="01" },
+    { machines=["astorm", "bloxeed", "pontoon"],  offset=0x18, data="01" },
+    { machine="mwalk",    offset=0x18, data="41" },
+    { setname="mwalku",   offset=0x18, data="c1" },
     # 5987 board
     # ddcrewu, ddcrew1, ddcrewj might be different
     # wwally's machine may be in a different MAME file, not segas18

--- a/cores/s18/hdl/jts18_main.v
+++ b/cores/s18/hdl/jts18_main.v
@@ -175,10 +175,12 @@ wire        dial_cs;
 wire        dial_rst;
 wire  [7:0] dial_dout;
 
-wire        mwalk    = game_id[6];
-wire        mwalka   = game_id[7]; // In US version switches are exchanged
-wire        ind_coin = (!dipsw[13]&&mwalk) ^ mwalka;
-wire        play3    = (!dipsw[12]&&mwalk) ^ mwalka;
+wire        mwalk, mwalka, ind_coin, play3;
+
+assign mwalk    = game_id[6];
+assign mwalka   = game_id[7]; // In US version switches are exchanged
+assign ind_coin = ~(dipsw[13]^mwalka) & mwalk;
+assign play3    = ~(dipsw[12]^mwalka) & mwalk;
 
 `ifndef NOMCU
 jtframe_8751mcu #(
@@ -362,7 +364,7 @@ always @(*) begin
         p3 = {joystick3[3:0],joystick3[7:4]};
         // MSB 7-6 are select inputs, used in Wally
         // It may be safe to connect to button 0
-        coinage = cab3 || play3 && ind_coin ?
+        coinage = cab3 || ( play3 && ind_coin ) ?
             { coin[0], cab_1p[2:0], service, dip_test, coin[1], coin[2] }:
             {   2'b11, cab_1p[1:0], service, dip_test, coin[1:0] };
         if( mwalk ) begin

--- a/cores/s18/hdl/jts18_main.v
+++ b/cores/s18/hdl/jts18_main.v
@@ -175,6 +175,11 @@ wire        dial_cs;
 wire        dial_rst;
 wire  [7:0] dial_dout;
 
+wire        mwalk    = game_id[6];
+wire        mwalka   = game_id[7]; // In US version switches are exchanged
+wire        ind_coin = (!dipsw[13]&&mwalk) ^ mwalka;
+wire        play3    = (!dipsw[12]&&mwalk) ^ mwalka;
+
 `ifndef NOMCU
 jtframe_8751mcu #(
     .DIVCEN     ( 1             ),
@@ -357,9 +362,14 @@ always @(*) begin
         p3 = {joystick3[3:0],joystick3[7:4]};
         // MSB 7-6 are select inputs, used in Wally
         // It may be safe to connect to button 0
-        coinage = cab3 ?
+        coinage = cab3 || play3 && ind_coin ?
             { coin[0], cab_1p[2:0], service, dip_test, coin[1], coin[2] }:
             {   2'b11, cab_1p[1:0], service, dip_test, coin[1:0] };
+        if( mwalk ) begin
+            p3[3]      = cab_1p[2];
+            coinage[6] = 1'b1;
+            if( !play3 ) coinage[1:0] = {coin[0],coin[1]};
+        end
     end
 end
 


### PR DESCRIPTION
This fixes #872 

For 2-player game, player-1 and player-2 coin positions are exchanged  in the coinage in relation to the generic configuration.

For 3 players, when "Coin chute" dip is set as "common",  only players 1 and 2 can add coins (This is what happens in MAME). For "Individual" all three coin buttons work for 3 players.

This removes `cab_1p[2]` from the `coinage` in 3-player mwalk, since it goes to `p3[3]` and having it in that position of the `coinage` leads to adding a coin for P3 whenever the start button is pressed.  

It also detects the US version of the game, since the dip switch values are switched in that version respect to the other