### PR TITLE
Increased pcm gain in aliens

### DIFF
--- a/cores/aliens/cfg/mem.yaml
+++ b/cores/aliens/cfg/mem.yaml
@@ -17,7 +17,7 @@ audio:
   rsum: 10k
   channels:
     - {name: fm,  module: jt51,     rsum:  6.2k,  rc: [{ r:  859,   c: 33n  }, {r: 1rout, c: 2.2n }]}
-    - {name: pcm, module: jt007232, rsum: 12.25k, rc: [{ r: 33k, c: 470p }], pre: 0.28 }
+    - {name: pcm, module: jt007232, rsum: 12.25k, rc: [{ r: 33k, c: 470p }], pre: 0.48 }
 sdram:
   banks:
     - buses:


### PR DESCRIPTION
Fixes #910

In the master version, in Crime Fighters, percussion cannot be heard clearly in comparison with the rest of the music. In Mame, this is easily differentiated when hearing.

I think it can be heard clearer with this gain value