### PR TITLE
Removing extra zero in 007232

### DIFF
--- a/cores/aliens/hdl/jtaliens_sound.v
+++ b/cores/aliens/hdl/jtaliens_sound.v
@@ -44,7 +44,7 @@ module jtaliens_sound(
 
     // Sound output
     output signed [15:0] fm_l, fm_r,
-    output signed [11:0] pcm,
+    output signed [10:0] pcm,
     // Debug
     input    [ 7:0] debug_bus,
     output   [ 7:0] st_dout

--- a/cores/castle/hdl/jtcastle_sound.v
+++ b/cores/castle/hdl/jtcastle_sound.v
@@ -41,7 +41,8 @@ module jtcastle_sound(
 
     // Sound output
     output signed [15:0] fm,
-    output signed [11:0] pcm_a, pcm_b, scc
+    output signed [11:0] scc,
+    output signed [10:0] pcm_a, pcm_b
 );
 `ifndef NOSOUND
 wire        [ 7:0]  cpu_dout, ram_dout, fm_dout, scc_dout;

--- a/cores/flane/hdl/jtflane_main.v
+++ b/cores/flane/hdl/jtflane_main.v
@@ -78,7 +78,7 @@ module jtflane_main(
     input               pcmd_ok,
 
     // Sound
-    output signed [11:0] pcm0, pcm1
+    output signed [10:0] pcm0, pcm1
 );
 
 wire [ 7:0] prot_dout, ram_dout;

--- a/cores/mx5k/hdl/jtmx5k_sound.v
+++ b/cores/mx5k/hdl/jtmx5k_sound.v
@@ -41,7 +41,7 @@ module jtmx5k_sound(
 
     // Sound output
     output signed [15:0] fm_l, fm_r,
-    output signed [11:0] pcm
+    output signed [10:0] pcm
 );
 `ifndef NOSOUND
 wire        [ 7:0]  cpu_dout, ram_dout, fm_dout;

--- a/cores/tmnt/hdl/jttmnt_sound.v
+++ b/cores/tmnt/hdl/jttmnt_sound.v
@@ -71,7 +71,7 @@ module jttmnt_sound(
     // Sound output
     output reg signed [15:0] title,
     output     signed [15:0] fm_l,  fm_r, k60_l, k60_r,
-    output     signed [11:0] pcm,
+    output     signed [10:0] pcm,
     output     signed [ 8:0] upd,
     // Debug
     input         [ 7:0] debug_bus,

--- a/modules/jt007232/hdl/jt007232.v
+++ b/modules/jt007232/hdl/jt007232.v
@@ -77,9 +77,9 @@ module jt007232(
     output            romb_cs,
     input             romb_ok,
     // sound output - scaled by register 12
-    output     signed [11:0] snda,
-    output     signed [11:0] sndb,
-    output     signed [11:0] snd,
+    output     signed [10:0] snda,
+    output     signed [10:0] sndb,
+    output     signed [10:0] snd,
     // debug
     input         [ 7:0] debug_bus,
     output reg    [ 7:0] st_dout
@@ -95,7 +95,7 @@ parameter REG12A=1, // location of CHA gain, the gain device is external to the
 
 reg [7:0] mmr[0:13]; // Not all bits are used
 
-wire signed [ 7:0] rawa, rawb;
+wire signed [ 6:0] rawa, rawb;
 // Channel A control
 wire [11:0] cha_pres = { mmr[1][3:0], mmr[0] };
 wire [16:0] cha_addr = { mmr[4][0], mmr[3], mmr[2] };
@@ -123,7 +123,7 @@ jt007232_gain #(.REG12A(REG12A)) u_gain(
     .sndb       ( sndb        )
 );
 
-jtframe_limsum #(.WI(12),.K(2)) u_limsum(
+jtframe_limsum #(.WI(11),.K(2)) u_limsum(
     .rst    ( rst   ),
     .clk    ( clk   ),
     .cen    ( 1'b1  ),

--- a/modules/jt007232/hdl/jt007232_channel.v
+++ b/modules/jt007232/hdl/jt007232_channel.v
@@ -33,10 +33,10 @@ module jt007232_channel(
     output            rom_cs,
     input             rom_ok,
     input      [ 7:0] rom_dout,
-    output reg signed [7:0] snd
+    output reg signed [6:0] snd
 );
 
-parameter [7:0] OFFSET='h40;
+parameter [6:0] OFFSET='h40;
 
 reg  [11:0] cnt;
 wire        over;
@@ -66,7 +66,7 @@ always @(posedge clk, posedge rst) begin
                     end else begin
                         rom_addr <= rom_addr + 1'd1;
                     end
-                    snd <= {1'b0, rom_dout[6:0]}-OFFSET;
+                    snd <= rom_dout[6:0]-OFFSET;
                     if( rom_dout[7] ) begin
                         if( loop )
                             rom_addr <= rom_start;

--- a/modules/jt007232/hdl/jt007232_gain.v
+++ b/modules/jt007232/hdl/jt007232_gain.v
@@ -20,8 +20,8 @@ module jt007232_gain(
     input                    clk,
     input                    swap_gains,   // makes ^ with REG12A below
     input             [ 7:0] reg12,
-    input      signed [ 7:0] rawa, rawb,
-    output reg signed [11:0] snda, sndb
+    input      signed [ 6:0] rawa, rawb,
+    output reg signed [10:0] snda, sndb
 );
 
 parameter REG12A=1;

--- a/modules/jt007232/ver/channel/gather.f
+++ b/modules/jt007232/ver/channel/gather.f
@@ -1,0 +1,1 @@
+../../hdl/jt007232_channel.v

--- a/modules/jt007232/ver/channel/test.v
+++ b/modules/jt007232/ver/channel/test.v
@@ -48,7 +48,6 @@ initial begin
     $finish;
 end
 
-
 jt007232_channel uut(
     .rst        ( rst     ),
     .clk        ( clk     ),

--- a/modules/jt007232/ver/channel/test.v
+++ b/modules/jt007232/ver/channel/test.v
@@ -1,12 +1,12 @@
 module test;
 
 localparam W=7; //8
-localparam [7:0] OFFSET='h40;
+localparam OFF=64;
 
 reg clk, rst;
 reg [7:0] dout;
 reg play;
-wire signed [W-1:0] snd;
+wire signed [W-1:0] snd_out;
 
 /*
 initial begin
@@ -22,7 +22,7 @@ initial begin
     forever #10 clk=~clk;
 end
 
-integer gain=0,exp;
+integer snd_in=0,exp;
 
 initial begin
     rst  = 1;
@@ -32,20 +32,14 @@ initial begin
     rst  = 0;
     @(posedge clk)
     play = 1;
-    for(gain=0;gain<256;gain=gain+1) begin
-        dout=gain[7:0];
+    for(snd_in=0;snd_in<128;snd_in=snd_in+1) begin
+        dout=snd_in[7:0];
         repeat (2) @(posedge clk);
-        exp = dout[6:0] - OFFSET;
+        exp = snd_in - OFF;
         @(posedge clk);
-        if(snd!=$signed(exp[W-1:0])) begin
-            $display("Bad value at rom_dout %d",dout);
-            $display("output vs expected: %d <> %d",snd,exp);
-            $display("FAIL");
-            $finish;
-        end
-        if( exp[30:W-1]!={32-W{exp[31]}}) begin
-            $display("Bad sign at rom_dout %d/%d",dout);
-            $display("output vs expected: %d <> %d",snd,exp);
+        if( {{32-W{snd_out[W-1]}},snd_out}!=exp) begin
+            $display("Bad signed value at rom_dout %d",dout);
+            $display("output vs expected: %d <> %d",snd_out,exp);
             $display("FAIL");
             $finish;
         end
@@ -69,7 +63,7 @@ jt007232_channel uut(
     .rom_cs     (         ),
     .rom_ok     ( 1'b1    ),
     .rom_dout   ( dout    ),
-    .snd        ( snd     )
+    .snd        ( snd_out )
 );
 
 endmodule

--- a/modules/jt007232/ver/channel/test.v
+++ b/modules/jt007232/ver/channel/test.v
@@ -1,0 +1,75 @@
+module test;
+
+localparam W=7; //8
+localparam [7:0] OFFSET='h40;
+
+reg clk, rst;
+reg [7:0] dout;
+reg play;
+wire signed [W-1:0] snd;
+
+/*
+initial begin
+    $dumpfile("test.lxt");
+    $dumpvars;
+    $dumpon;
+    #10000000 $finish;
+end
+*/
+
+initial begin
+    clk=0;
+    forever #10 clk=~clk;
+end
+
+integer gain=0,exp;
+
+initial begin
+    rst  = 1;
+    play = 0;
+    dout=0;
+    repeat (20) @(posedge clk);
+    rst  = 0;
+    @(posedge clk)
+    play = 1;
+    for(gain=0;gain<256;gain=gain+1) begin
+        dout=gain[7:0];
+        repeat (2) @(posedge clk);
+        exp = dout[6:0] - OFFSET;
+        @(posedge clk);
+        if(snd!=$signed(exp[W-1:0])) begin
+            $display("Bad value at rom_dout %d",dout);
+            $display("output vs expected: %d <> %d",snd,exp);
+            $display("FAIL");
+            $finish;
+        end
+        if( exp[30:W-1]!={32-W{exp[31]}}) begin
+            $display("Bad sign at rom_dout %d/%d",dout);
+            $display("output vs expected: %d <> %d",snd,exp);
+            $display("FAIL");
+            $finish;
+        end
+    end
+    $display("PASS");
+    $finish;
+end
+
+
+jt007232_channel uut(
+    .rst        ( rst     ),
+    .clk        ( clk     ),
+    .cen_q      ( 1'b1    ),
+    .rom_start  ( 17'h0   ),
+    .pre0       ( 12'hFFF ),
+    .pre_sel    ( 2'b0    ),
+    .loop       ( 1'b1    ),
+    .play       ( play    ),
+    .load       ( 1'b1    ),
+    .rom_addr   (         ),
+    .rom_cs     (         ),
+    .rom_ok     ( 1'b1    ),
+    .rom_dout   ( dout    ),
+    .snd        ( snd     )
+);
+
+endmodule

--- a/modules/jt007232/ver/gain/test.v
+++ b/modules/jt007232/ver/gain/test.v
@@ -1,9 +1,9 @@
 module test;
 
-localparam W=12;
+localparam W=11;
 
 reg clk;
-reg signed [7:0] rawa, rawb;
+reg signed [6:0] rawa, rawb;
 reg [7:0] reg12;
 wire signed [W-1:0] snda, sndb;
 

--- a/modules/jtframe/hdl/sound/audio_mod.yaml
+++ b/modules/jtframe/hdl/sound/audio_mod.yaml
@@ -21,7 +21,7 @@ jt5232:   { data_width: 16, unsigned: true, vpp: 1.0 }
 # output is 1.2Vpp, rather than the AY's 1V
 jt03_psg: { data_width: 10, unsigned: true, dcrm: true, vpp: 0.72, rout: 253 }
 # jt007232: resistor DAC is external
-jt007232: { data_width: 12, vpp: 1.0       }
+jt007232: { data_width: 11, vpp: 1.0       }
 jt7759:   { data_width:  9, vpp: 1.0       }
 
 # OKI compatible


### PR DESCRIPTION
As it is stated in https://github.com/jotego/jtcores/issues/910#issuecomment-2578720641, the extra zero is removed here and a test for checking the length of the channel module is added

By now, the only core where this correction has been added is in aliens.

However, I have not perceived a big difference in the pcm sound after this changed (tested in Crime Fighters only)