### PR TITLE
minor: outrun msg

### DIFF
--- a/cores/outrun/cfg/msg
+++ b/cores/outrun/cfg/msg
@@ -13,9 +13,10 @@
          measurements
 
         Known Issues:
- - Blank in the middle of the road
- - Blank lines in the sprite layer
- for very large sprites
+ - Blank in the middle
+        of the road
+ - Blank lines in the sprite
+ layer for very large sprites
 
          \BJTKCHAMP\W
     FPGA core by \RJOTEGO\W

--- a/modules/jtframe/bin/lint-one.sh
+++ b/modules/jtframe/bin/lint-one.sh
@@ -30,5 +30,6 @@ fi
 jtsim -lint -$TARGET $*
 EXIT=$?
 jtframe msg $CORE
+EXIT=$(($EXIT || $?))
 rm -rf $TEST_FOLDER
 exit $EXIT

--- a/modules/jtframe/bin/lint-one.sh
+++ b/modules/jtframe/bin/lint-one.sh
@@ -29,5 +29,6 @@ fi
 
 jtsim -lint -$TARGET $*
 EXIT=$?
+jtframe msg $CORE
 rm -rf $TEST_FOLDER
 exit $EXIT

--- a/modules/jtframe/bin/lint-one.sh
+++ b/modules/jtframe/bin/lint-one.sh
@@ -1,35 +1,68 @@
-#!/bin/bash
+#!/bin/bash -e
 # use lint-one.sh core -u JTFRAME_SKIP
 # for cores in development phase
 
-CORE=$1
-shift
-if [ -z "$TARGET" ]; then
-    TARGET=mister
-fi
+trap "clean_up; exit 1" INT KILL
 
-eval `jtframe cfgstr $CORE --output bash --target $TARGET $*`
+main() {
+    CORE=$1
+    shift
+    set_target
+    read_core_macros
 
-if [[ ! -e $CORES/$CORE/cfg/macros.def || -e $CORES/$CORE/cfg/skip || -v JTFRAME_SKIP ]]; then
-    echo "Skipping $CORE"
-    exit 0
-fi
+    if must_skip; then
+        echo "Skipping $CORE"
+        exit 0
+    fi
 
-cd $CORES/$CORE
-TEST_FOLDER=ver/lint
-rm -rf $TEST_FOLDER
-mkdir -p $TEST_FOLDER
-cd $TEST_FOLDER
+    prepare_test_folder
+    cd $TEST_FOLDER
+    make_dummy_rom
 
-if [ ! -e rom.bin ]; then
-    # dummy ROM
-    dd if=/dev/zero of=rom.bin count=1 2> /dev/null
-    DELROM=
-fi
+    run_linter
+    check_msg
+    clean_up
+}
 
-jtsim -lint -$TARGET $*
-EXIT=$?
-jtframe msg $CORE
-EXIT=$(($EXIT || $?))
-rm -rf $TEST_FOLDER
-exit $EXIT
+set_target() {
+    if [ -z "$TARGET" ]; then
+        TARGET=mister
+    fi
+}
+
+read_core_macros() {
+    eval `jtframe cfgstr $CORE --output bash --target $TARGET $*`
+}
+
+must_skip() {
+    [[ ! -e $CORES/$CORE/cfg/macros.def || -e $CORES/$CORE/cfg/skip || -v JTFRAME_SKIP ]]
+}
+
+prepare_test_folder() {
+    cd $CORES/$CORE
+    TEST_FOLDER=ver/lint
+    rm -rf $TEST_FOLDER
+    mkdir -p $TEST_FOLDER
+}
+
+make_dummy_rom() {
+    if [ ! -e rom.bin ]; then
+        # dummy ROM
+        dd if=/dev/zero of=rom.bin count=1 2> /dev/null
+        DELROM=
+    fi
+}
+
+run_linter() {
+    jtsim -lint -$TARGET $*
+}
+
+check_msg() {
+    jtframe msg $CORE
+}
+
+clean_up() {
+    rm -rf $TEST_FOLDER
+}
+
+main $*


### PR DESCRIPTION
Reduced number of characters per line in cfg/msg for fixing compilation error