### PR TITLE
Duplicated line in toml

### DIFF
--- a/cores/midres/cfg/mame2mra.toml
+++ b/cores/midres/cfg/mame2mra.toml
@@ -38,7 +38,7 @@ regions = [
     { name="gfx2",     start="GFX2_START",width=16, No_offset=true,  sequence=[0,2,1,3]},
     { name="gfx3",     width=16, No_offset=true },
 
-    { name="gfx4",     start="JTFRAME_BA3_START", width=32, No_offset=true, sequence=[0,1,2,3]},
+    { name="gfx4",     start="JTFRAME_BA3_START", width=32, No_offset=true },
 
     { name="sub",      start="MCU_START" },
     { name="mcu",      start="MCU_START" },

--- a/cores/midres/cfg/mame2mra.toml
+++ b/cores/midres/cfg/mame2mra.toml
@@ -38,10 +38,8 @@ regions = [
     { name="gfx2",     start="GFX2_START",width=16, No_offset=true,  sequence=[0,2,1,3]},
     { name="gfx3",     width=16, No_offset=true },
 
-    { name="gfx4",     start="JTFRAME_BA3_START", width=32, No_offset=true, name_sort=[
-        "fl01","fl03","fl00","fl02"] },
+    { name="gfx4",     start="JTFRAME_BA3_START", width=32, No_offset=true, sequence=[0,1,2,3]},
 
-    { name="gfx4",     start="JTFRAME_BA3_START", width=32, No_offset=true, sort_even=true },
     { name="sub",      start="MCU_START" },
     { name="mcu",      start="MCU_START" },
     { name="proms",    start="JTFRAME_PROM_START" },


### PR DESCRIPTION
Removing the second version, keeps the md5 the same as original.
Removed "name_sort" since it uses the same order as in cpp file