### PR TITLE
fixes sprites breaking when changing size

### DIFF
--- a/cores/simson/hdl/jt053246_scan.sv
+++ b/cores/simson/hdl/jt053246_scan.sv
@@ -97,7 +97,6 @@ always @(posedge clk) begin
                        simson    ? 10'h117 : 10'h107); // Vendetta
     vscl <= rd_pzoffset(vzoom[9:0]);
     hscl <= rd_pzoffset(hzoom[9:0]);
-    y2      <= y + {1'b0,ymove};
     ydiff_b <= y2 + { vlatch[8], vlatch };
     /* verilator lint_off WIDTH */
     yz_add  <= vzoom[9:0]*ydiff_b; // vzoom < 10'h40 enlarge, >10'h40 reduce
@@ -126,6 +125,7 @@ endfunction
 
 always @* begin : B
     ymove     = zmove( vsz, vscl );
+    y2        = y + {1'b0,ymove};
     ydiff     = yz_add[6+:10];
     x2        = x - zmove( hsz, hscl );
     left_wrap = x2 < HDUMP_MIN;


### PR DESCRIPTION
Related to #841 

From 51f5ad595250084a0be405d50a67fbf601056736 some sprites would break in jtsimson when changing size

![5](https://github.com/user-attachments/assets/c9942b2b-c88a-4f9e-af66-60b752002b23)

This fixes the issue