### PR TITLE
Remove name_sort from roadf TOML

### DIFF
--- a/cores/roadf/cfg/mame2mra.toml
+++ b/cores/roadf/cfg/mame2mra.toml
@@ -43,8 +43,7 @@ regions = [
     { name="maincpu" },
     { name="audiocpu" },
     { name="tiles", width=16, no_offset=true, Sort_even=true, start="SCR_START" },
-    { machine="roadf", name="sprites", width=16, no_offset=true, start="OBJ_START" },
-    { machine="hyperspt", name="sprites", width=16, no_offset=true, start="OBJ_START", Name_sort=["c14","c18","c13","c17","c12","c16","c11","c15"] },
+    { name="sprites", width=16, no_offset=true, start="OBJ_START" },
     { name="vlm", start="PCM_START" },
     { name="proms", start="JTFRAME_PROM_START" },
 ]

--- a/cores/roadf/cfg/mame2mra.toml
+++ b/cores/roadf/cfg/mame2mra.toml
@@ -43,7 +43,8 @@ regions = [
     { name="maincpu" },
     { name="audiocpu" },
     { name="tiles", width=16, no_offset=true, Sort_even=true, start="SCR_START" },
-    { name="sprites", width=16, no_offset=true, start="OBJ_START" },
+    { machine="roadf", name="sprites", width=16, no_offset=true, start="OBJ_START" },
+    { machine="hyperspt", name="sprites", width=16, no_offset=true, start="OBJ_START", sequence=[0,4,1,5,2,6,3,7] },
     { name="vlm", start="PCM_START" },
     { name="proms", start="JTFRAME_PROM_START" },
 ]


### PR DESCRIPTION
Comparing with the order used in `hyperspt.cpp`, I first used:
```
{ machine="hyperspt", name="sprites", width=16, no_offset=true, start="OBJ_START", sequence=[0,4,1,5,2,6,3,7] },
```
However, this changed the md5 code for Hyper Sports.
In the original version, even though `Name_sort=["c14","c18","c13","c17","c12","c16","c11","c15"]` is used, the created MRA states:

```
        <!-- OBJ_START -->
        <!-- sprites - starts at 0x20000 - length 0x10000 (16 bits) -->
        <interleave output="16">
            <part name="c14" crc="c72d63be" map="01"/>
            <part name="c13" crc="76565608" map="10"/>
        </interleave>
        <interleave output="16">
            <part name="c12" crc="74d2cc69" map="01"/>
            <part name="c11" crc="66cbcb4d" map="10"/>
        </interleave>
        <interleave output="16">
            <part name="c18" crc="ed25e669" map="01"/>
            <part name="c17" crc="b145b39f" map="10"/>
        </interleave>
        <interleave output="16">
            <part name="c16" crc="d7ff9f2b" map="01"/>
            <part name="c15" crc="f3d454e6" map="10"/>
        </interleave>
```

Keeping the original order

This commit maintains the md5, but I am not sure if this is the correct output or not

Closes #971 