### PR TITLE
Analog Stick controlling crosshair

### DIFF
--- a/modules/jtframe/hdl/jtframe_lightgun.v
+++ b/modules/jtframe/hdl/jtframe_lightgun.v
@@ -20,6 +20,8 @@ module jtframe_lightgun (
     input         rst,
     input         clk,
     input         vs,
+    input  [15:0] joyana1,
+    input  [15:0] joyana2,
     input  [15:0] mouse_1p,
     input  [15:0] mouse_2p,
     input  [ 1:0] mouse_strobe,
@@ -39,37 +41,44 @@ parameter WIDTH = 384, HEIGHT = 224,
           YOFFSET= `ifdef JTFRAME_LIGHTGUN_YOFFSET `JTFRAME_LIGHTGUN_YOFFSET `else 0 `endif;
 
 `ifdef JTFRAME_LIGHTGUN
-jtframe_mouse_abspos #(.W(WIDTH),.H(HEIGHT),
+`define JTFRAME_MOUSE_NOEMU
+wire [1:0] strobe;
+
+jtframe_lightgun_mux #(.W(WIDTH),.H(HEIGHT),
     .XOFFSET(XOFFSET),.YOFFSET(YOFFSET)
-) crosshair_left (
-    .clk        ( clk             ),
-    .dx         ( mouse_1p[ 7: 0] ),
-    .dy         ( mouse_1p[15: 8] ),
-    .strobe     ( mouse_strobe[0] ),
-    .x          ( gun_1p_x        ),
-    .y          ( gun_1p_y        ),
-    .x_abs      ( cross1_x        ),
-    .y_abs      ( cross1_y        )
+) crosshair_left(
+    .rst          ( rst             ),
+    .clk          ( clk             ),
+    .joyana       ( joyana1         ),
+    .mouse        ( mouse_1p        ),
+    .mouse_strobe ( mouse_strobe[0] ),
+    .strobe       ( strobe[0]       ),
+    .gun_x        ( gun_1p_x        ),
+    .gun_y        ( gun_1p_y        ),
+    .cross_x      ( cross1_x        ),
+    .cross_y      ( cross1_y        )
 );
 
-jtframe_mouse_abspos #(.W(WIDTH),.H(HEIGHT),
+jtframe_lightgun_mux #(.W(WIDTH),.H(HEIGHT),
     .XOFFSET(XOFFSET),.YOFFSET(YOFFSET)
-) crosshair_center (
-    .clk        ( clk             ),
-    .dx         ( mouse_2p[ 7: 0] ),
-    .dy         ( mouse_2p[15: 8] ),
-    .strobe     ( mouse_strobe[1] ),
-    .x          ( gun_2p_x        ),
-    .y          ( gun_2p_y        ),
-    .x_abs      ( cross2_x        ),
-    .y_abs      ( cross2_y        )
+) crosshair_center(
+    .rst          ( rst             ),
+    .clk          ( clk             ),
+    .joyana       ( joyana2         ),
+    .mouse        ( mouse_2p        ),
+    .mouse_strobe ( mouse_strobe[1] ),
+    .strobe       ( strobe[1]       ),
+    .gun_x        ( gun_2p_x        ),
+    .gun_y        ( gun_2p_y        ),
+    .cross_x      ( cross2_x        ),
+    .cross_y      ( cross2_y        )
 );
 
 jtframe_crosshair_disable crosshair_disable(
     .rst        ( rst             ),
     .clk        ( clk             ),
     .vs         ( vs              ),
-    .strobe     ( mouse_strobe    ),
+    .strobe     ( strobe          ),
     .en_b       ( cross_disable   )
 );
 
@@ -80,5 +89,62 @@ assign {cross1_x, cross1_y} = 18'b0;
 assign {cross2_x, cross2_y} = 18'b0;
 assign  cross_disable   =  2'd3;
 `endif
+
+endmodule
+
+module jtframe_lightgun_mux(
+    input         rst,
+    input         clk,
+    input  [15:0] joyana,
+    input  [15:0] mouse,
+    input         mouse_strobe,
+    output        strobe,
+    output [ 8:0] gun_x,
+    output [ 8:0] gun_y,
+    output [ 8:0] cross_x,
+    output [ 8:0] cross_y
+);
+
+parameter W = 384, H = 224, XOFFSET=0, YOFFSET=0;
+
+wire [8:0] mouse_x, mouse_y, joyana_x, joyana_y;
+wire       a_strobe;
+
+jtframe_mouse_abspos #(.W(W),.H(H)
+) crosshair_mouse(
+    .clk        ( clk             ),
+    .dx         ( mouse[ 7: 0]    ),
+    .dy         ( mouse[15: 8]    ),
+    .strobe     ( mouse_strobe    ),
+    .x          ( mouse_x         ),
+    .y          ( mouse_y         )
+);
+
+jtframe_joyana_abspos #(.W(W),.H(H)
+) crosshair_joyana(
+    .clk        ( clk             ),
+    .joyana     ( joyana          ),
+    .strobe     ( a_strobe        ),
+    .x          ( joyana_x        ),
+    .y          ( joyana_y        )
+);
+
+jtframe_lightgun_position #(
+    .XOFFSET(XOFFSET),.YOFFSET(YOFFSET)
+) crosshair_mux(
+    .rst        ( rst             ),
+    .clk        ( clk             ),
+    .m_x        ( mouse_x         ),
+    .m_y        ( mouse_y         ),
+    .m_strobe   ( mouse_strobe    ),
+    .a_x        ( joyana_x        ),
+    .a_y        ( joyana_y        ),
+    .a_strobe   ( a_strobe        ),
+    .x          ( gun_x           ),
+    .y          ( gun_y           ),
+    .x_abs      ( cross_x         ),
+    .y_abs      ( cross_y         ),
+    .strobe     ( strobe          )
+);
 
 endmodule

--- a/modules/jtframe/hdl/keyboard/jtframe_inputs.v
+++ b/modules/jtframe/hdl/keyboard/jtframe_inputs.v
@@ -268,6 +268,8 @@ jtframe_lightgun #(.WIDTH(WIDTH), .HEIGHT(HEIGHT)
     .cross_disable( cross_disable ),
     .mouse_1p     ( mouse_1p      ),
     .mouse_2p     ( mouse_2p      ),
+    .joyana1      ( ana1          ),
+    .joyana2      ( ana2          ),
     .mouse_strobe ( mouse_strobe  ),
     .gun_1p_x     ( gun_1p_x      ),
     .gun_1p_y     ( gun_1p_y      ),


### PR DESCRIPTION
Route connecting Analog stick signal and crosshair gun coordinates.
Sinden lightguns send screen position through analog joystick signal.

With these changes, crosshair can be seen correctly where one is aiming with the lightgun. However, crosshair position using lightgun is shaky, therefore producing failures in shooting tests due to the fast changes. This shaky behaviour is not seen when using an actual joystick

JTFRAME_MOUSE_NOEMU was defined since it interferes with the analog joystick detection