### PR TITLE
s18/lghost: sprites correctly addressed

### DIFF
--- a/cores/s18/cfg/mame2mra.toml
+++ b/cores/s18/cfg/mame2mra.toml
@@ -67,8 +67,8 @@ data = [
     # 5987 board
     # ddcrewu, ddcrew1, ddcrewj might be different
     # wwally's machine may be in a different MAME file, not segas18
-    { machines=["desertbr","wwallyj","lghost"], offset=0x18, data="02" }, # 5987 with 2MB ROM
-    { machines=["cltchitr", "ddcrew"], offset=0x18, data="04" },
+    { machines=["desertbr","wwallyj"], offset=0x18, data="02" }, # 5987 with 2MB ROM
+    { machines=["cltchitr", "ddcrew","lghost"], offset=0x18, data="04" },
     # single-game boards
     { machine="hamaway",  offset=0x18, data="08" }, # 837-7525
     { machine="shdancer", offset=0x18, data="20" }, # 837-7248-01


### PR DESCRIPTION
Fixes #1058 

