### PR TITLE
minor

### DIFF
--- a/cores/outrun/hdl/jtoutrun_video.v
+++ b/cores/outrun/hdl/jtoutrun_video.v
@@ -236,7 +236,6 @@ jts16_tilemap #(.MODEL(1),.SCR2_DLY(10'd10)) u_tilemap(
     .dswn       ( main_dswn ),
     .char_dout  ( char_dout ),
     .vint       ( vint      ),
-    .active     (           ),
 
     // Other configuration
     .flip       ( flip      ),
@@ -282,6 +281,7 @@ jts16_tilemap #(.MODEL(1),.SCR2_DLY(10'd10)) u_tilemap(
     .shadow     ( shadow    ),
     .set_fix    ( 1'b1      ),  // fixed layer always on top
     // Selected layer
+    .obj        (           ),
     .sa         ( sa        ),
     .sb         ( sb        ),
     .fix        ( fix       ),

--- a/cores/s16/hdl/jts16_prio.v
+++ b/cores/s16/hdl/jts16_prio.v
@@ -33,10 +33,10 @@ module jts16_prio(
     output reg         sa,        // active high
     output reg         sb,
     output reg         fix,
+    output reg         obj,
     output reg         tprio,     // selected tile map priority
     output reg         scr1_prio,
     output reg         scr2_prio,
-    output reg  [ 3:0] active,
 
     output reg [10:0]  pal_addr,
     output reg         shadow,
@@ -67,6 +67,7 @@ endfunction
 reg  [ 6:0] char_g;
 reg  [10:0] scr1_g, scr2_g;
 reg  [11:0] obj_g;
+reg  [ 3:0] active;
 
 always @(*) begin
     char_g = char_pxl;
@@ -97,7 +98,7 @@ always @(*) begin
                (lyr2[10] ? lyr2[3:0]!=0 : lyr2[2:0]!=0) ? 4'b100 : (
                 4'b0 )));
     if( pal_addr[10] ) active=4'b1000; // OBJ
-    { sb, sa, fix } = active[2:0];
+    { obj, sb, sa, fix } = active;
     tprio = fix ? char_g[6] : sa ? scr1_g[10] : scr2_g[10];
     scr1_prio = scr1_g[10];
     scr2_prio = scr2_g[10];

--- a/cores/s16/hdl/jts16_tilemap.v
+++ b/cores/s16/hdl/jts16_tilemap.v
@@ -95,10 +95,10 @@ module jts16_tilemap(
     output             fix,     // CHAR selected (?)
     output             sa,      // SCR1 selected (?)
     output             sb,      // SCR2 selected (?)
+    output             obj,     // OBJ  selected (?)
     output             tprio,   // priority bit of selected tile map layer
     output             s1_pri,
     output             s2_pri,
-    output      [ 3:0] active,
     // Set top priority
     input              set_fix,
 
@@ -356,13 +356,13 @@ jts16_prio u_prio(
     .set_fix   ( set_fix        ),
 
     // Selected layer
+    .obj       ( obj            ),
     .sa        ( sa             ),
     .sb        ( sb             ),
     .fix       ( fix            ),
     .tprio     ( tprio          ),
     .scr1_prio ( s1_pri         ),
     .scr2_prio ( s2_pri         ),
-    .active    ( active         ),
 
     .pal_addr  ( pal_addr       ),
     .shadow    ( shadow         ),

--- a/cores/s16/hdl/jts16_video.v
+++ b/cores/s16/hdl/jts16_video.v
@@ -171,7 +171,7 @@ jts16_tilemap #(.MODEL(MODEL)) u_tilemap(
     .st_dout    ( st_dout   ),
     .scr_bad    ( scr_bad   ),
     // Active layer
-    .active     (           ),
+    .obj        (           ),
     .fix        (           ),
     .sa         (           ),
     .sb         (           ),

--- a/cores/s18/hdl/jts18_colmix.v
+++ b/cores/s18/hdl/jts18_colmix.v
@@ -26,9 +26,8 @@ module jts18_colmix(
     output             LHBL_dly,
     output             LVBL_dly,
     // S16B
-    input              vid16_en, sa, sb, fix, s1_pri, s2_pri,
+    input              vid16_en, obj16, sa, sb, fix, s1_pri, s2_pri,
     input        [1:0] obj_prio,
-    input        [3:0] active,
     // VDP
     input              vdp_en,
     input        [2:0] vdp_prio,
@@ -70,7 +69,7 @@ always @(posedge clk) begin
     //     4: vdp_sel <= !fix && ( sa || sb );
     //     default: vdp_sel <= s16_blank;
     // endcase
-    nblnk   <= active==0;
+    nblnk   <= {obj16, sa, sb, fix}==0;
     vdp_sel <= vdp_sel_o;
     if(  nblnk    ) vdp_sel <= 1;
     if( !vdp_ysn  ) vdp_sel <= 0;

--- a/cores/s18/hdl/jts18_video.v
+++ b/cores/s18/hdl/jts18_video.v
@@ -117,10 +117,10 @@ wire       vdp_hs, vdp_vs, vdp_hde, vdp_vde, vdp_spa_b, vdp_ysn;
 wire       scr_hs, scr_vs, scr_lvbl, scr_lhbl;
 wire       LHBL_dly, LVBL_dly, HS48, VS48, LHBL48, LVBL48,
            scr1_sel, scr2_sel, vdp_on,
-           sa, sb, fix, s1_pri, s2_pri;
+           obj, sa, sb, fix, s1_pri, s2_pri;
 wire [1:0] obj_prio;
 wire [2:0] scr1_bank, scr2_bank;
-wire [3:0] obj_bank, active;
+wire [3:0] obj_bank;
 (* ramstyle = "logic" *) reg  [7:0] tilebanks[16];
 
 wire       alt_gfx = game_id[PCB_5987_DESERTBR]|game_id[PCB_5987]|game_id[PCB_7525];
@@ -211,7 +211,7 @@ jts18_video16 u_video16(
     .obj_data   ( obj_data  ),
 
     // Video signal
-    .active     ( active    ),
+    .obj        ( obj       ),
     .sa         ( sa        ),
     .sb         ( sb        ),
     .fix        ( fix       ),
@@ -285,13 +285,13 @@ jts18_colmix u_colmix(
     .vdp_prio   ( vdp_prio  ),
     .vid16_en   ( vid16_en  ),
     // S16 Video priority
+    .obj16     ( obj       ),
     .sa         ( sa        ),
     .sb         ( sb        ),
     .fix        ( fix       ),
     .obj_prio   ( obj_prio  ),
     .s1_pri     ( s1_pri    ),
     .s2_pri     ( s2_pri    ),
-    .active     ( active    ),
 
     .LHBL       ( LHBL      ),
     .LVBL       ( LVBL      ),

--- a/cores/s18/hdl/jts18_video16.v
+++ b/cores/s18/hdl/jts18_video16.v
@@ -83,9 +83,8 @@ module jts18_video16(
     output     [ 5:0]  blue,
 
     // priority bits
-    output     [ 3:0] active,
     output     [ 1:0]  obj_prio,
-    output             fix, sa, sb, tprio, s1_pri, s2_pri,
+    output             fix, sa, sb, obj, tprio, s1_pri, s2_pri,
     // palette RAM
     output     [11:1]  pal_addr,
     input      [15:0]  pal_dout,
@@ -174,7 +173,7 @@ jts16_tilemap #(.MODEL(MODEL),.HS_END(9'hA0),
     .st_dout    ( st_dout   ),
     .scr_bad    ( scr_bad   ),
     // Active layer
-    .active     ( active    ),
+    .obj        ( obj       ),
     .fix        ( fix       ),
     .sa         (  sa       ),
     .sb         (  sb       ),


### PR DESCRIPTION
Removed `active` bus and substituted it by single signal `obj`

The whole `active` bus was unnecessary due to most of its bits already routed to `s18_colmix`. 

I called it `obj16` in `s18_colmix` because there was already a signal called `obj`. 
I need to check if this old signal can be removed in favor of the new one, but it needs to be worked together with the VDP priority check, since its now in use there