### PR TITLE
Modified installation script to be more robust

### DIFF
--- a/modules/jtframe/bin/install/jotego_20.04.sh
+++ b/modules/jtframe/bin/install/jotego_20.04.sh
@@ -54,7 +54,7 @@ sudo apt install --yes parallel locate python3-pip fatattr sshpass gawk libxml2-
 sudo updatedb
 
 # KiCAD
-sudo add-apt-repository -y ppa:kicad/kicad-8.0-releases
+sudo add-apt-repository --yes ppa:kicad/kicad-8.0-releases
 sudo apt update
 sudo apt install --yes occt-misc=7.6.3+dfsg1-7.1build1 libocct-visualization-7.6t64
 sudo apt install --yes kicad
@@ -67,10 +67,10 @@ sudo locale-gen en_US.UTF-8
 if command -v python3.11 >/dev/null 2>&1; then
     PYTHON=python3.11
 else
-    sudo apt install -y software-properties-common
-    sudo add-apt-repository -y ppa:deadsnakes/ppa
+    sudo apt install --yes software-properties-common
+    sudo add-apt-repository --yes ppa:deadsnakes/ppa
     sudo apt update
-    sudo apt install -y python3.11 python3.11-distutils
+    sudo apt install --yes python3.11 python3.11-distutils
     PYTHON=python3.11
 fi
 if ! $PYTHON -m pip --version >/dev/null 2>&1; then
@@ -192,12 +192,12 @@ go install golang.org/x/tools/cmd/goimports@latest
 go install golang.org/x/tools/cmd/godoc@latest
 
 # GitHub CLI
-type -p curl >/dev/null || (sudo apt update && sudo apt install curl -y)
+type -p curl >/dev/null || (sudo apt update && sudo apt install curl --yes)
 curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
 && sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
 && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
 && sudo apt update \
-&& sudo apt install gh -y
+&& sudo apt install gh --yes
 
 # Set up repositories
 cat<<EOF
@@ -218,8 +218,8 @@ EOF
 sudo $JTFRAME/bin/jtblaster
 
 # audio play and visualization
-sudo apt install -y mplayer audacity
+sudo apt install --yes mplayer audacity
 
 # Cross-Compiler
 # m68k-linux-gnu-gcc
-sudo apt install -y gcc-m68k-linux-gnu
+sudo apt install --yes gcc-m68k-linux-gnu

--- a/modules/jtframe/bin/install/jotego_20.04.sh
+++ b/modules/jtframe/bin/install/jotego_20.04.sh
@@ -56,6 +56,7 @@ sudo updatedb
 # KiCAD
 sudo add-apt-repository -y ppa:kicad/kicad-8.0-releases
 sudo apt update
+sudo apt install --yes occt-misc=7.6.3+dfsg1-7.1build1 libocct-visualization-7.6t64
 sudo apt install --yes kicad
 
 # Locale

--- a/modules/jtframe/bin/install/jotego_20.04.sh
+++ b/modules/jtframe/bin/install/jotego_20.04.sh
@@ -34,12 +34,15 @@ sudo apt install --yes libfl2 libfl-dev zlib1g zlib1g-dev
 sudo apt install --yes flex gperf bison
 
 # libpng12, required by Quartus 17
-wget https://downloads.sourceforge.net/libpng/libpng-1.2.59.tar.gz
-tar -xvzf libpng-1.2.59.tar.gz
-cd libpng-1.2.59
+cd /tmp
+LIBPNG="libpng-1.2.59"
+wget https://downloads.sourceforge.net/libpng/$LIBPNG.tar.gz
+tar -xvzf $LIBPNG.tar.gz
+cd $LIBPNG
 ./configure
 make
 sudo make install
+rm -rf $LIBPNG $LIBPNG.tar.gz
 
 # required by MAME
 sudo apt install --yes libqwt-qt5-dev libsdl2-dev libfontconfig1-dev libsdl2-ttf-dev \
@@ -51,7 +54,7 @@ sudo apt install --yes parallel locate python3-pip fatattr sshpass gawk libxml2-
 sudo updatedb
 
 # KiCAD
-sudo add-apt-repository ppa:kicad/kicad-8.0-releases
+sudo add-apt-repository -y ppa:kicad/kicad-8.0-releases
 sudo apt update
 sudo apt install --yes kicad
 
@@ -60,64 +63,98 @@ sudo apt install --yes locales locales-all
 sudo locale-gen en_US.UTF-8
 
 # open picoblaze assembler needed for assembling the cheat and beta code
-python -m pip install --user --no-build-isolation "setuptools<58" "wheel<0.38"
-python -m pip install --user --no-build-isolation opbasm
+if command -v python3.11 >/dev/null 2>&1; then
+    PYTHON=python3.11
+else
+    sudo apt install -y software-properties-common
+    sudo add-apt-repository -y ppa:deadsnakes/ppa
+    sudo apt update
+    sudo apt install -y python3.11 python3.11-distutils
+    PYTHON=python3.11
+fi
+if ! $PYTHON -m pip --version >/dev/null 2>&1; then
+    curl -fsSL https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py
+    $PYTHON /tmp/get-pip.py --user
+fi
+PIP="$PYTHON -m pip"
+
+$PIP install --user --upgrade "setuptools<58" "wheel<0.38"
+$PIP install --user opbasm
+
+USER_BIN="$HOME/.local/bin"
+if ! echo "$PATH" | grep -q "$USER_BIN"; then
+  echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
+fi
 
 # as31 to compile 8051/8751 assembler code
 sudo apt install --yes as31
 
 # asm48 to compile MCS-48 assembler code
-cd /tmp
-git clone https://github.com/jotego/asm48.git
-cd asm48
-make
-sudo cp 8039dasm asm48 /usr/local/bin
+if ! command -v asm48 >/dev/null 2>&1; then
+    cd /tmp
+    git clone https://github.com/jotego/asm48.git
+    cd asm48
+    make
+    sudo cp 8039dasm asm48 /usr/local/bin
+    rm -rf /tmp/asm48
+fi
 
 # macro assembler for many, many CPUs
-cd /tmp
-wget http://john.ccac.rwth-aachen.de:8000/ftp/as/source/c_version/asl-current.tar.gz
-tar xfz asl-current.tar.gz
-cd asl-current
-if [[ "$arch" == "arch64" ]]; then
-    ln -s Makefile.def-samples/Makefile.def-arm-apple-linux Makefile.def
-elif [[ "$arch" == "amd64" ]]; then
-    ln -s Makefile.def-samples/Makefile.def-x86_64-unknown-linux Makefile.def
+if ! command -v asl >/dev/null 2>&1; then
+    cd /tmp
+    wget http://john.ccac.rwth-aachen.de:8000/ftp/as/source/c_version/asl-current.tar.gz
+    tar xfz asl-current.tar.gz
+    cd asl-current
+    if [[ "$arch" == "arch64" ]]; then
+        ln -s Makefile.def-samples/Makefile.def-arm-apple-linux Makefile.def
+    elif [[ "$arch" == "amd64" ]]; then
+        ln -s Makefile.def-samples/Makefile.def-x86_64-unknown-linux Makefile.def
+    fi
+    make
+    sudo cp alink asl p2bin p2hex pbind plist /usr/local/bin
+    sudo mkdir -p /usr/local/share/man/man1/
+    sudo cp man/* /usr/local/share/man/man1/
+    rm -rf /tmp/asl-current.tar.gz /tmp/asl-current
 fi
-make
-sudo cp alink asl p2bin p2hex pbind plist /usr/local/bin
-sudo mkdir -p /usr/local/share/man/man1/
-sudo cp man/* /usr/local/share/man/man1/
 
 # MRA tool to generate .arc files
-cd /tmp
-git clone https://github.com/mist-devel/mra-tools-c.git
-cd mra-tools-c
-make -j
-sudo mv mra /usr/local/bin/mra
+if ! command -v mra >/dev/null 2>&1; then
+    cd /tmp
+    git clone https://github.com/mist-devel/mra-tools-c.git
+    cd mra-tools-c
+    make -j
+    sudo mv mra /usr/local/bin/mra
+    rm -rf /tmp/mra-tools-c
+fi
 
 # Verilator
 sudo apt install --yes git help2man perl python3 make autoconf g++ flex bison ccache
 sudo apt install --yes libgoogle-perftools-dev numactl perl-doc
 
-cd $HOME
-unset VERILATOR_ROOT
-git clone https://github.com/verilator/verilator.git --depth 1 || exit $?
-cd $HOME/verilator
-autoconf
-./configure
-# compile using 80% of available CPUs
-make -j $((`nproc`*4/5))
-export VERILATOR_ROOT=`pwd`
-echo export VERILATOR_ROOT=`pwd` >> $HOME/.bashrc
+if [ ! -d "$HOME/verilator/.git" ]; then
+    cd $HOME
+    unset VERILATOR_ROOT
+    git clone https://github.com/verilator/verilator.git --depth 1 || exit $?
+    cd $HOME/verilator
+    autoconf
+    ./configure
+    # compile using 80% of available CPUs
+    make -j $((`nproc`*4/5))
+    export VERILATOR_ROOT=`pwd`
+    echo export VERILATOR_ROOT=`pwd` >> $HOME/.bashrc
+fi
 
 # Icarus Verilog
-git clone https://github.com/steveicarus/iverilog.git
-cd iverilog
-git checkout v12_0
-sh autoconf.sh
-./configure
-make -j $((`nproc`*4/5))
-sudo make install
+if [ ! -d "$VERILATOR_ROOT/iverilog/.git" ]; then
+    cd $VERILATOR_ROOT
+    git clone https://github.com/steveicarus/iverilog.git
+    cd iverilog
+    git checkout v12_0
+    sh autoconf.sh
+    ./configure
+    make -j $((`nproc`*4/5))
+    sudo make install
+fi
 
 # nice to have
 sudo apt install --yes htop flameshot ghex imagemagick
@@ -163,7 +200,8 @@ curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo 
 
 # Set up repositories
 cat<<EOF
-Run these commands after setting the SSH key in GitHub
+
+Run these commands after setting the SSH key in GitHub:
 
 cd $HOME
 git clone --recurse-submodules git@github.com:jotego/jtcores.git
@@ -172,13 +210,14 @@ cd jtmisc
 git clone --depth 1 --shallow-since="$(date --date='-2 weeks' +%F)" git@github.com:jotego/jtbin.git
 git clone git@github.com:jotego/jtbeta.git
 git clone git@github.com:JTFPGA/jtutil.git
+
 EOF
 
 # USB Blaster
-jtblaster
+sudo $JTFRAME/bin/jtblaster
 
 # audio play and visualization
-sudo apt install mplayer audacity
+sudo apt install -y mplayer audacity
 
 # Cross-Compiler
 # m68k-linux-gnu-gcc

--- a/modules/jtframe/bin/install/jotego_20.04.sh
+++ b/modules/jtframe/bin/install/jotego_20.04.sh
@@ -222,4 +222,4 @@ sudo apt install -y mplayer audacity
 
 # Cross-Compiler
 # m68k-linux-gnu-gcc
-sudo apt install gcc-m68k-linux-gnu
+sudo apt install -y gcc-m68k-linux-gnu


### PR DESCRIPTION
The installation script has been modified to be more robust in the following ways:
- You don't need to press enter when adding the `kicad` repository
- A specific version of `occt-misc` is installed before kicad to avoid issues with broken dependencies
- The generated temporary files will be removed once used
- `asm`, `verilator`, `icarus verilog`, `asl` and `mra` won't be installed if they are already installed
- To install `opbasm`, `python11` will be installed and the version requirements of `setuptools` and `wheel` will be also installed
- `jtblaster` command will be executed with sudo as needed
- You don't have to confirm the installation of `mplayer`, `audacity` and `gcc-m68k-linux-gnu`