### PR TITLE
riders: scene simulation working again in glfgreat

### DIFF
--- a/cores/riders/hdl/jtglfgreat_encoder.v
+++ b/cores/riders/hdl/jtglfgreat_encoder.v
@@ -39,7 +39,7 @@ module jtglfgreat_encoder(
     output     [71:0] dec_din,
     output reg        dec_we
 );
-
+`ifndef NOMAIN
 // tilemap reader
 reg  [ 8:0] y, x;
 reg  [ 3:0] st;
@@ -181,5 +181,20 @@ always @(posedge clk) begin
         end
     end
 end
+`else
+initial begin
+    done     = 1;
+    psclo_cs = 0;
+    t2x2_we  = 0;
+    dec_addr = 0;
+    dec_we   = 0;
+end
 
+assign psclo_addr = 0;
+assign pschi_addr = 0;
+assign pschi_cs   = 0;
+assign t2x2_addr  = 0;
+assign t2x2_din   = 0;
+assign dec_din    = 0;
+`endif
 endmodule

--- a/cores/riders/hdl/jtriders_psac.v
+++ b/cores/riders/hdl/jtriders_psac.v
@@ -165,7 +165,7 @@ jtglfgreat_encoder u_encoder(
     .dec_we     ( dec_we    )
 );
 /* verilator tracing_off */
-jtframe_dual_ram #(.AW(17),.DW(13)) u_2x2tilemap (
+jtframe_dual_ram #(.AW(17),.DW(13),.SIMHEXFILE("tilemap_2x2.hex")) u_2x2tilemap (
     // Port 0 - programming during power up
     .clk0       ( clk       ),
     .addr0      ( t2x2_addr ),
@@ -180,7 +180,7 @@ jtframe_dual_ram #(.AW(17),.DW(13)) u_2x2tilemap (
     .q1         ( encoded   )
 );
 
-jtframe_dual_ram #(.AW(13),.DW(72)) u_decoder (
+jtframe_dual_ram #(.AW(13),.DW(72),.SIMHEXFILE("decoder.hex")) u_decoder (
     // Port 0 - programming during power up
     .clk0       ( clk       ),
     .addr0      ( dec_addr  ),

--- a/cores/riders/ver/game/rest2bin.sh
+++ b/cores/riders/ver/game/rest2bin.sh
@@ -1,3 +1,19 @@
 #!/bin/bash -e
 
-../game/dump_split.sh -f "rest.bin" --fullobj --psac_mmr
+PSAC=
+FSIZE=$(wc -c <"rest.bin")
+
+if [[ $FSIZE -gt 0x90A1 ]]; then
+	PSAC="--psac_mmr"
+
+	dd if=sdram_bank3.bin of=AB.bin skip=3584 count=1024 bs=1024
+	dd if=sdram_bank3.bin of=CC.bin skip=4608 count=256  bs=1024
+
+	jtutil drop1 -l  < "AB.bin" >  "A.bin"
+	jtutil drop1     < "AB.bin" >  "B.bin"
+	jtutil drop1     < "CC.bin" >  "C.bin"
+
+	python ../glfgreat/tilemap_blocks.py
+fi
+
+../game/dump_split.sh -f "rest.bin" --fullobj $PSAC

--- a/cores/riders/ver/glfgreat/tilemap_blocks.py
+++ b/cores/riders/ver/glfgreat/tilemap_blocks.py
@@ -1,8 +1,8 @@
 # Building Blocks Tilemap
 
-A="061b07.18d"
-B="061b06.16d"
-C="061b05.15d"
+A="A.bin" # "061b07.18d"
+B="B.bin" # "061b06.16d"
+C="C.bin" # "061b05.15d"
 
 def read_file(bf):
     with open(bf, 'rb') as f:
@@ -88,5 +88,5 @@ for bank in range(2):
 print("Number of individual blocks: ", len(blocks))
 print(len(newmap))
 
-create_hex_file("compressed_tilemap.hex",hexlist)
-create_hex_file("reference_tilemap.hex",newmap,1)
+create_hex_file("tilemap_2x2.hex",hexlist)
+create_hex_file("decoder.hex",newmap,1)


### PR DESCRIPTION
- Ignoring encoder when ' NOMAIN' is defined, since it is a time consuming process and not possible in a scene simulation
- The three files needed by `tilemap_blocks.py` are regenerated from the memory banks in `rest2bin.sh`
- `tilemap_blocks.py`  generates the compressed tilemap and reference needed for the simulation