### PR TITLE
Fixed jtcore13 to use Ubuntu 20.04

### DIFF
--- a/modules/jtframe/devops/build-dockers.sh
+++ b/modules/jtframe/devops/build-dockers.sh
@@ -16,21 +16,10 @@ main(){
         prepare_builder false "$BUILDER_NAME"
     fi
 
-    declare -A CTX_BASE=(
-        [jtframe]="$JTFRAME"
-    )
-    declare -A CTX_JTCORE13=(
-        [jtframe]="$JTFRAME"
-        [altera]="/opt/altera"
-    )
-    declare -A CTX_FPGA=(
-        [intel]="/opt/intelFPGA_lite"
-    )
-
-    build "jtcore-base" "linux/amd64,linux/arm64"   CTX_BASE
-    build "jtcore13"    "linux/amd64"               CTX_JTCORE13
-    build "jtcore17"    "linux/amd64"               CTX_FPGA
-    build "jtcore20"    "linux/amd64"               CTX_FPGA
+    build "jtcore-base" "linux/amd64,linux/arm64"   "$JTFRAME"
+    build "jtcore13"    "linux/amd64"               "$JTFRAME" "/opt/altera"
+    build "jtcore17"    "linux/amd64"               "/opt/intelFPGA_lite"
+    build "jtcore20"    "linux/amd64"               "/opt/intelFPGA_lite"
     build "linter"      "linux/amd64,linux/arm64"
     build "simulator"   "linux/amd64,linux/arm64"
 
@@ -57,17 +46,13 @@ prepare_builder() {
 }
 
 build() {
-    local image=$1
-    local platforms=$2
-    local contexts_map_name=${3-}
+    local image=$1; shift
+    local platforms=$1; shift
 
     local -a build_contexts=()
-    if [[ -n "$contexts_map_name" ]]; then
-        local -n ctx_ref="$contexts_map_name"
-        for name in "${!ctx_ref[@]}"; do
-            build_contexts+=( --build-context "$name=${ctx_ref[$name]}" )
-        done
-    fi
+    for path in "$@"; do
+        build_contexts+=( --build-context "$(basename $path)=$path" )
+    done
 
     echo "Building jotego/$image..."
     if $PUSH_IMAGES; then

--- a/modules/jtframe/devops/build-dockers.sh
+++ b/modules/jtframe/devops/build-dockers.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 
 BUILDER_NAME="jotego-builder"
+BUILDER_NAME_MULTIARCH="jotego-multiarch-builder"
 
 main(){
     SUCCESS=()
@@ -9,46 +10,75 @@ main(){
     parse_args "$@"
 
     if $PUSH_IMAGES; then
-        prepare_builder $BUILDER_NAME
+        prepare_builder true "$BUILDER_NAME_MULTIARCH"
         docker login
+    else
+        prepare_builder false "$BUILDER_NAME"
     fi
 
-    build "jtcore-base" "$JTFRAME"              "linux/amd64,linux/arm64"
-    build "jtcore13"    "/opt/altera"           "linux/amd64"
-    build "jtcore17"    "/opt/intelFPGA_lite"   "linux/amd64"
-    build "jtcore20"    "/opt/intelFPGA_lite"   "linux/amd64"
-    build "linter"      "."                     "linux/amd64,linux/arm64"
-    build "simulator"   "."                     "linux/amd64,linux/arm64"
+    declare -A CTX_BASE=(
+        [jtframe]="$JTFRAME"
+    )
+    declare -A CTX_JTCORE13=(
+        [jtframe]="$JTFRAME"
+        [altera]="/opt/altera"
+    )
+    declare -A CTX_FPGA=(
+        [intel]="/opt/intelFPGA_lite"
+    )
+
+    build "jtcore-base" "linux/amd64,linux/arm64"   CTX_BASE
+    build "jtcore13"    "linux/amd64"               CTX_JTCORE13
+    build "jtcore17"    "linux/amd64"               CTX_FPGA
+    build "jtcore20"    "linux/amd64"               CTX_FPGA
+    build "linter"      "linux/amd64,linux/arm64"
+    build "simulator"   "linux/amd64,linux/arm64"
 
     print_results
 }
 
 prepare_builder() {
-    local name=$1
-    if ! docker buildx inspect "$name" >/dev/null 2>&1; then
-        echo "Creating buildx builder '$name'..."
+    local multiarch=$1
+    local name=$2
+
+    if docker buildx inspect "$name" >/dev/null 2>&1; then
+        docker buildx use "$name"
+        docker buildx inspect --bootstrap
+        return
+    fi
+
+    echo "Creating buildx builder '$name'..."
+    if $multiarch; then 
         docker buildx create --name "$name" --driver "docker-container" --use
     else
-        docker buildx use "$name"
+        docker buildx create --name "$name" --use
     fi
     docker buildx inspect --bootstrap
 }
 
 build() {
     local image=$1
-    local path=$2
-    local platforms=$3
+    local platforms=$2
+    local contexts_map_name=${3-}
+
+    local -a build_contexts=()
+    if [[ -n "$contexts_map_name" ]]; then
+        local -n ctx_ref="$contexts_map_name"
+        for name in "${!ctx_ref[@]}"; do
+            build_contexts+=( --build-context "$name=${ctx_ref[$name]}" )
+        done
+    fi
 
     echo "Building jotego/$image..."
     if $PUSH_IMAGES; then
-        if docker buildx build --platform "$platforms" --file $image.df --tag jotego/$image:latest --push $path; then
+        if docker buildx build "${build_contexts[@]}" --platform "$platforms" --file "$image.df" --tag "jotego/$image:latest" --push .; then
             SUCCESS+=("$image")
         else
             echo "Build failed for $image"
             FAIL+=("$image")
         fi
     else
-        if docker build --file $image.df --tag jotego/$image:latest --load $path; then
+        if docker buildx build "${build_contexts[@]}" --file "$image.df" --tag "jotego/$image:latest" --load .; then
             SUCCESS+=("$image")
         else
             echo "Build failed for $image"

--- a/modules/jtframe/devops/jtcore-base.df
+++ b/modules/jtframe/devops/jtcore-base.df
@@ -29,11 +29,11 @@ ENV PATH="$PATH:/usr/local/go/bin"
 
 # JTFRAME dependencies
 WORKDIR /jtframe
-COPY src/jtframe/go.mod src/jtframe/go.sum ./
+COPY --from=jtframe src/jtframe/go.mod src/jtframe/go.sum ./
 RUN go mod download
 
 WORKDIR /jtutil
-COPY src/jtutil/go.mod src/jtutil/go.sum ./
+COPY --from=jtframe src/jtutil/go.mod src/jtutil/go.sum ./
 RUN go mod download
 
 WORKDIR /

--- a/modules/jtframe/devops/jtcore13.df
+++ b/modules/jtframe/devops/jtcore13.df
@@ -1,12 +1,77 @@
-FROM jotego/jtcore-base
+FROM ubuntu:20.04
 LABEL maintainer=jotego@gmail.com
+
+RUN apt-get update
+RUN ln -fs /usr/share/zoneinfo/Europe/Madrid /etc/localtime
+RUN apt-get install --yes --quiet git curl gawk
+RUN apt-get install --yes --quiet ca-certificates libgnutls30
+RUN apt-get install --yes --quiet ftp figlet xmlstarlet flex
+RUN apt-get install --yes --quiet rsync
+
+# Python
+RUN apt-get install --yes --quiet python python3-pip && pip install pypng
+
+# Go
+RUN OS=$(uname -s | tr '[:upper:]' '[:lower:]') && \
+    GOVER=1.23.4 && \
+    GONAME=go${GOVER}.${OS}-amd64.tar.gz && \
+    curl -LO https://go.dev/dl/${GONAME} && \
+    tar -C /usr/local -xzf ${GONAME} && \
+    rm -f ${GONAME}
+ENV PATH="$PATH:/usr/local/go/bin"
+
+# JTFRAME dependencies
+WORKDIR /jtframe
+COPY src/jtframe/go.mod src/jtframe/go.sum ./
+RUN go mod download
+
+WORKDIR /jtutil
+COPY src/jtutil/go.mod src/jtutil/go.sum ./
+RUN go mod download
+
+WORKDIR /
+RUN rm --recursive --force jtframe jtutil
+
+# iverilog compilation
+RUN apt-get install --yes --quiet build-essential git zlib1g-dev
+RUN apt-get install --yes --quiet flex gperf bison
+
+# Assembler tools
+RUN pip install --upgrade opbasm
+RUN apt-get install --yes --quiet as31
+RUN cd /tmp && \
+    git clone https://github.com/jotego/asl.git && \
+    cd asl && \
+    make -j && \
+    cp alink asl p2bin p2hex pbind plist /usr/local/bin
+
+# JT core environment
+RUN mkdir /jtbin && \
+    echo export JTBIN=/jtbin >> $HOME/.bashrc
+
+# Locales
+RUN apt-get update
+RUN apt-get install locales locales-all
+RUN locale-gen en_US.UTF-8
+RUN echo LC_ALL=en_US.UTF-8 >> /etc/environment
+RUN echo LANG=en_US.UTF-8 >> /etc/environment
+
+# Needed by Quartus 17
+RUN apt-get install --yes libglib2.0-0
+
+# Needed by xjtcore.sh
+RUN apt-get install --yes xxd
 
 # 32-bit support
 RUN dpkg --add-architecture i386 && apt update
 
 # 32-bit libraries
-RUN ln -fs /usr/share/zoneinfo/Europe/Madrid /etc/localtime && apt-get install -y tzdata && dpkg-reconfigure --frontend noninteractive tzdata
-RUN apt install make:i386 libxdmcp6:i386 libxau6:i386 libxext6:i386 libxft-dev:i386 libxft2:i386 libxrender1:i386 libxt6:i386 libfontconfig1-dev:i386 libxtst6:i386 libx11-6:i386 unixodbc:i386 libzmq3-dev:i386 libxext6:i386 libxi6:i386 -y
+RUN apt-get install --yes tzdata && \
+    dpkg-reconfigure --frontend noninteractive tzdata
+RUN apt-get install --yes make:i386 libxdmcp6:i386 libxau6:i386 \
+    libxext6:i386 libxft-dev:i386 libxft2:i386 libxrender1:i386 \
+    libxt6:i386 libfontconfig1-dev:i386 libxtst6:i386 libx11-6:i386 \
+    unixodbc:i386 libzmq3-dev:i386 libxext6:i386 libxi6:i386
 # missing ncurses-base:i386 -y
 
 COPY 13.1 /opt/altera/13.1

--- a/modules/jtframe/devops/jtcore13.df
+++ b/modules/jtframe/devops/jtcore13.df
@@ -22,11 +22,11 @@ ENV PATH="$PATH:/usr/local/go/bin"
 
 # JTFRAME dependencies
 WORKDIR /jtframe
-COPY src/jtframe/go.mod src/jtframe/go.sum ./
+COPY --from=jtframe src/jtframe/go.mod src/jtframe/go.sum ./
 RUN go mod download
 
 WORKDIR /jtutil
-COPY src/jtutil/go.mod src/jtutil/go.sum ./
+COPY --from=jtframe src/jtutil/go.mod src/jtutil/go.sum ./
 RUN go mod download
 
 WORKDIR /
@@ -74,7 +74,7 @@ RUN apt-get install --yes make:i386 libxdmcp6:i386 libxau6:i386 \
     unixodbc:i386 libzmq3-dev:i386 libxext6:i386 libxi6:i386
 # missing ncurses-base:i386 -y
 
-COPY 13.1 /opt/altera/13.1
+COPY --from=altera 13.1 /opt/altera/13.1
 ENV PATH=$PATH:/opt/altera/13.1/quartus/bin
 
 ENTRYPOINT ["bash"]

--- a/modules/jtframe/devops/jtcore17.df
+++ b/modules/jtframe/devops/jtcore17.df
@@ -1,7 +1,7 @@
 FROM jotego/jtcore-base
 LABEL maintainer=jotego@gmail.com
 
-COPY --from=intel 17.1 /opt/intelFPGA_lite/17.1
+COPY --from=intelFPGA_lite 17.1 /opt/intelFPGA_lite/17.1
 ENV PATH=$PATH:/opt/intelFPGA_lite/17.1/quartus/bin
 
 ENTRYPOINT ["bash"]

--- a/modules/jtframe/devops/jtcore17.df
+++ b/modules/jtframe/devops/jtcore17.df
@@ -1,7 +1,7 @@
 FROM jotego/jtcore-base
 LABEL maintainer=jotego@gmail.com
 
-COPY 17.1 /opt/intelFPGA_lite/17.1
+COPY --from=intel 17.1 /opt/intelFPGA_lite/17.1
 ENV PATH=$PATH:/opt/intelFPGA_lite/17.1/quartus/bin
 
 ENTRYPOINT ["bash"]

--- a/modules/jtframe/devops/jtcore20.df
+++ b/modules/jtframe/devops/jtcore20.df
@@ -2,12 +2,12 @@ FROM jotego/jtcore-base
 LABEL maintainer=jotego@gmail.com
 
 RUN mkdir -p /opt/intelFPGA_lite/20.1
-COPY 20.1/devdata   /opt/intelFPGA_lite/20.1/devdata
-COPY 20.1/ip        /opt/intelFPGA_lite/20.1/ip
-COPY 20.1/licenses  /opt/intelFPGA_lite/20.1/licenses
-COPY 20.1/logs      /opt/intelFPGA_lite/20.1/logs
-COPY 20.1/quartus   /opt/intelFPGA_lite/20.1/quartus
-COPY 20.1/uninstall /opt/intelFPGA_lite/20.1/uninstall
+COPY --from=intel 20.1/devdata   /opt/intelFPGA_lite/20.1/devdata
+COPY --from=intel 20.1/ip        /opt/intelFPGA_lite/20.1/ip
+COPY --from=intel 20.1/licenses  /opt/intelFPGA_lite/20.1/licenses
+COPY --from=intel 20.1/logs      /opt/intelFPGA_lite/20.1/logs
+COPY --from=intel 20.1/quartus   /opt/intelFPGA_lite/20.1/quartus
+COPY --from=intel 20.1/uninstall /opt/intelFPGA_lite/20.1/uninstall
 ENV PATH=$PATH:/opt/intelFPGA_lite/20.1/quartus/bin
 
 

--- a/modules/jtframe/devops/jtcore20.df
+++ b/modules/jtframe/devops/jtcore20.df
@@ -2,12 +2,12 @@ FROM jotego/jtcore-base
 LABEL maintainer=jotego@gmail.com
 
 RUN mkdir -p /opt/intelFPGA_lite/20.1
-COPY --from=intel 20.1/devdata   /opt/intelFPGA_lite/20.1/devdata
-COPY --from=intel 20.1/ip        /opt/intelFPGA_lite/20.1/ip
-COPY --from=intel 20.1/licenses  /opt/intelFPGA_lite/20.1/licenses
-COPY --from=intel 20.1/logs      /opt/intelFPGA_lite/20.1/logs
-COPY --from=intel 20.1/quartus   /opt/intelFPGA_lite/20.1/quartus
-COPY --from=intel 20.1/uninstall /opt/intelFPGA_lite/20.1/uninstall
+COPY --from=intelFPGA_lite 20.1/devdata   /opt/intelFPGA_lite/20.1/devdata
+COPY --from=intelFPGA_lite 20.1/ip        /opt/intelFPGA_lite/20.1/ip
+COPY --from=intelFPGA_lite 20.1/licenses  /opt/intelFPGA_lite/20.1/licenses
+COPY --from=intelFPGA_lite 20.1/logs      /opt/intelFPGA_lite/20.1/logs
+COPY --from=intelFPGA_lite 20.1/quartus   /opt/intelFPGA_lite/20.1/quartus
+COPY --from=intelFPGA_lite 20.1/uninstall /opt/intelFPGA_lite/20.1/uninstall
 ENV PATH=$PATH:/opt/intelFPGA_lite/20.1/quartus/bin
 
 


### PR DESCRIPTION
This image has been modified to use Ubuntu 20.04 due to some compatibility issues with some i386 libraries.
For that purpose, it can no longer be based on `jtcore-base`, so it has to install all dependencies that `jtcore-base` used to do.