### PR TITLE
riders/glfgreat: psac compressed tilemap moved to BRAM

### DIFF
--- a/cores/riders/cfg/mem.yaml
+++ b/cores/riders/cfg/mem.yaml
@@ -112,7 +112,7 @@ bram:
       rw: true
   # PSAC Tilemap 2x2
   - name: t2x2
-    unless: [ NOPSAC ]
+    unless: [ NOPSAC, POCKET ]
     data_width: 16
     addr_width: 18
     sim_file: true

--- a/cores/riders/cfg/mem.yaml
+++ b/cores/riders/cfg/mem.yaml
@@ -110,3 +110,13 @@ bram:
       din:  ram_din
       dout: lmem_dout
       rw: true
+  # PSAC Tilemap 2x2
+  - name: t2x2
+    unless: [ POCKET ]
+    data_width: 16
+    addr_width: 18
+    sim_file: true
+    rw: true
+    dual_port:
+      name: tmap
+      dout: encoded

--- a/cores/riders/cfg/mem.yaml
+++ b/cores/riders/cfg/mem.yaml
@@ -112,7 +112,7 @@ bram:
       rw: true
   # PSAC Tilemap 2x2
   - name: t2x2
-    unless: [ POCKET ]
+    unless: [ NOPSAC ]
     data_width: 16
     addr_width: 18
     sim_file: true

--- a/cores/riders/hdl/jtriders_game.v
+++ b/cores/riders/hdl/jtriders_game.v
@@ -46,6 +46,9 @@ wire [ 1:0] oram_we;
 wire [ 1:0] lmem_we;
 wire [15:0] lmem_dout=0, line_dout=0;
 wire [10:1] line_addr;
+wire [17:1] tx2x2_addr, tmap_addr;
+wire [15:0] t2x2_din, encoded=0;
+wire [ 1:0] t2x2_we;
 `endif
 
 assign debug_view = debug_mux;

--- a/cores/riders/hdl/jtriders_game.v
+++ b/cores/riders/hdl/jtriders_game.v
@@ -253,6 +253,12 @@ jtriders_video u_video (
 
     .line_addr      ( line_addr     ),
     .line_dout      ( line_dout     ),
+
+    .t2x2_addr      ( t2x2_addr     ),
+    .t2x2_din       ( t2x2_din      ),
+    .t2x2_we        ( t2x2_we       ),
+    .tmap_addr      ( tmap_addr     ),
+    .encoded        ( encoded       ),
     // SDRAM
     .lyra_addr      ( lyra_addr     ),
     .lyrb_addr      ( lyrb_addr     ),

--- a/cores/riders/hdl/jtriders_video.v
+++ b/cores/riders/hdl/jtriders_video.v
@@ -106,6 +106,13 @@ module jtriders_video(
 
     output     [10:1] line_addr,
     input      [15:0] line_dout,
+
+    output     [17:1] t2x2_addr,
+    output     [15:0] t2x2_din,
+    output     [ 1:0] t2x2_we,
+    output     [17:1] tmap_addr,
+    input      [15:0] encoded,
+
     // Color
     input      [ 2:0] dim,
     input             dimmod,
@@ -328,6 +335,11 @@ jtriders_psac u_psac(
     .line_addr  ( line_addr ),
     .line_dout  ( line_dout ),
 
+    .t2x2_addr  ( t2x2_addr ),
+    .t2x2_din   ( t2x2_din  ),
+    .t2x2_we    ( t2x2_we   ),
+    .tmap_addr  ( tmap_addr ),
+    .encoded    ( encoded   ),
     // Tiles
     .rom_addr   ( psc_addr  ),
     .rom_data   ( psc_data  ),
@@ -340,7 +352,8 @@ jtriders_psac u_psac(
 );
 `else
 assign psc_cs=0,psclo_cs=0,pschi_cs=0,psc_pxl=0, line_addr=0,
-    pschi_addr=0, psclo_addr=0,psc_addr=0,enc_done=0,psac_mmr=0;
+    pschi_addr=0, psclo_addr=0,psc_addr=0,enc_done=0,psac_mmr=0,
+    t2x2_addr=0,t2x2_din=0,t2x2_we=0,tmap_addr=0;
 `endif
 
 wire [ 1:0] lyro_pri;

--- a/cores/riders/ver/game/rest2bin.sh
+++ b/cores/riders/ver/game/rest2bin.sh
@@ -14,6 +14,10 @@ if [[ $FSIZE -gt 0x8821 ]]; then
 	jtutil drop1     < "CC.bin" >  "C.bin"
 
 	python ../glfgreat/tilemap_blocks.py
+
+	cut -c2-5 tilemap_2x2.hex | xxd -r -p > t2x2.bin
+	jtutil drop1 -l  < "t2x2.bin" >  "t2x2_hi.bin"
+	jtutil drop1     < "t2x2.bin" >  "t2x2_lo.bin"
 fi
 
 ../game/dump_split.sh -f "rest.bin" --fullobj $PSAC


### PR DESCRIPTION
I haven't used `unless: [ POCKET ]` in mem.yaml, since it should not be included  in the smaller FPGAs either and the Pocket's SRAM is not implemented in the core yet

Is it possible to use `unless: [ NOPSAC | POCKET ] ` in `mem.yaml`? 