### PR TITLE
minor: Regression script print help

### DIFF
--- a/modules/jtframe/bin/run_regression.sh
+++ b/modules/jtframe/bin/run_regression.sh
@@ -124,7 +124,7 @@ parse_args() {
     local_rom=false
     push=false
 
-    if [[ $1 == --help ]]; then
+    if [[ $1 == --help || $1 == -h ]]; then
         echo "Usage: $0 <core> <setname> [--frames <number_of_frames>] [--port <ssh_port>] [--user <sftp_user>] [--host <server_ip>] [--path REMOTE_DIR] [--check] [--local-check LOCAL_DIR] [--local-rom] [--push] [-h|--help]"
         echo ""
         print_help
@@ -143,7 +143,7 @@ parse_args() {
         --local-check) shift; local_check=true; LOCAL_DIR="$1" ;;
         --local-rom) local_rom=true ;;
         --push) push=true ;;
-        --help)
+        -h|--help)
             echo "Usage: $0 <core> <setname> [--frames <number_of_frames>] [--port <ssh_port>] [--user <sftp_user>] [--host <server_ip>] [--path REMOTE_DIR] [--check] [--local-check LOCAL_DIR] [--local-rom] [--push] [-h|--help]"
             echo ""
             print_help

--- a/modules/jtframe/bin/run_regression.sh
+++ b/modules/jtframe/bin/run_regression.sh
@@ -124,15 +124,15 @@ parse_args() {
     local_rom=false
     push=false
 
-    if [[ $# -lt 2 ]]; then
-        echo "Usage: $0 <core> <setname> [--frames <number_of_frames>] [--port <ssh_port>] [--user <sftp_user>] [--host <server_ip>] [--path REMOTE_DIR] [--check] [--local-check LOCAL_DIR] [--local-rom] [--push] [-h|--help]"
-        exit 1
-    fi
     if [[ $1 == --help ]]; then
         echo "Usage: $0 <core> <setname> [--frames <number_of_frames>] [--port <ssh_port>] [--user <sftp_user>] [--host <server_ip>] [--path REMOTE_DIR] [--check] [--local-check LOCAL_DIR] [--local-rom] [--push] [-h|--help]"
         echo ""
         print_help
         exit 0
+    fi
+    if [[ $# -lt 2 ]]; then
+        echo "Usage: $0 <core> <setname> [--frames <number_of_frames>] [--port <ssh_port>] [--user <sftp_user>] [--host <server_ip>] [--path REMOTE_DIR] [--check] [--local-check LOCAL_DIR] [--local-rom] [--push] [-h|--help]"
+        exit 1
     fi
     core=$1; shift
     setname=$1; shift


### PR DESCRIPTION
In the master version, if you use `run_regression.sh --help` the script will respond as if you are using too few arguments.

You would need to add more useless arguments to get it to print the help text. Changing the order, `print --help` works as it should