### PR TITLE
Fix sprites riders/paroda

### DIFF
--- a/cores/simson/hdl/jt053246_dma.v
+++ b/cores/simson/hdl/jt053246_dma.v
@@ -102,7 +102,7 @@ always @(posedge clk) begin
             lvbl_sh    <= lvbl_sh<<1;
             lvbl_sh[0] <= lvbl;
         end
-        if(!dma_bsy && (trigger || (dma_44&&dma_en)) ) begin
+        if(!dma_bsy && (trigger || dma_44) ) begin
             dma_bsy  <= 1;
             dma_clr  <= 1;
             dma_wait <= !k44_en && mode8; // 8-bit speed: 595us, 16-bit: 297.5us


### PR DESCRIPTION
Commit 21064bcbfb060f60ff2f11a0f098e0cbf9970bcd broke the sprites in Paroda and Riders, since they share the `jt053246_dma` module

In the previous version, the other trigger was ignored in this line for for these cores in favor of `dma44`.  think `dma_en` is barely used in these cores, making the sprites completely disappear

For rungun, simson and xmen, this change is harmless, since `dma44` is fixed to 0 in these