### PR TITLE
ngp/ngpc: power button needs 3 seconds

### DIFF
--- a/cores/ngp/hdl/jtngp_game.v
+++ b/cores/ngp/hdl/jtngp_game.v
@@ -27,11 +27,9 @@ wire [ 7:0] snd_latch, main_latch, ioctl_pal, ioctl_main,
 wire [ 1:0] cpu_we, shd_we;
 reg  [ 7:0] st_mux;
 reg  [ 3:0] cart_size;
-wire [ 1:0] pressed_b;
-reg         pressed_l, pwr_press;
 wire        gfx_cs,
             flash0_cs, flash0_rdy, flash0_ok,
-            flash1_cs, flash1_rdy, flash1_ok, f1g_gcs;
+            flash1_cs, flash1_rdy, flash1_ok, f1g_gcs, pwr_press;
 wire        snd_ack, snd_nmi, snd_irq, mute_enb, snd_rstn, ioctl_rest, mode;
 wire        hirq, virq, main_int5, pwr_button, poweron, halted;
 reg         cart_l;
@@ -75,19 +73,7 @@ end
 
 assign ioctl_din = ioctl_addr[7] ? ioctl_pal : ioctl_main;
 
-always @(posedge clk) begin
-    pressed_l <= ~pressed_b[0];
-    pwr_press <= ~&{pressed_b[0],pressed_l};
-end
-
-jtframe_crosshair_disable #(.CNTW(7)) u_power_onoff(
-    .rst        ( rst             ),
-    .clk        ( clk             ),
-    .vs         ( VS              ),
-    .strobe     ( {1'b1,coin[0]}  ),
-    .pulse      (                 ),
-    .en_b       ( pressed_b       )
-);
+jtngp_pwr u_power_onoff(rst, clk, VS, coin[0], pwr_press);
 
 /* verilator tracing_on */
 jtngp_main u_main(

--- a/cores/ngp/hdl/jtngp_pwr.v
+++ b/cores/ngp/hdl/jtngp_pwr.v
@@ -1,0 +1,54 @@
+/*  This file is part of JTFRAME.
+    JTFRAME program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    JTFRAME program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with JTFRAME.  If not, see <http://www.gnu.org/licenses/>.
+
+    Author: Rafael Eduardo Paiva Feener. Copyright: Miki Saito
+    Version: 1.0
+    Date: 04-11-2025 */
+
+// This module generates a pulse when button (active low) is pressed for a number of frames determined by CNTW
+// Use for replicating real-life console power button needing long-pressing to work
+
+module jtngp_pwr #(parameter CNTW=7)(
+    input      rst,
+    input      clk,
+    input      vs,
+    input      button,
+    output reg pwr_press
+);
+
+wire pressed, vs_edge;
+reg  pressed_l;
+
+always @(posedge clk) begin
+    pressed_l <=   ~pressed;
+    pwr_press <= ~&{pressed,pressed_l};
+end
+
+jtframe_countup #(.W(CNTW)
+)u_pressed(
+    .rst   ( button  ),
+    .clk   ( clk     ),
+    .cen   ( vs_edge ),
+    .v     ( pressed )
+);
+
+jtframe_edge cnt_pulse(
+    .rst   ( rst     ),
+    .clk   ( clk     ),
+    .edgeof( vs      ),
+    .clr   ( vs_edge ),
+    .q     ( vs_edge )
+);
+
+endmodule


### PR DESCRIPTION
The added module counts the frames while `coin[0]==0` (pressed).
If pressed long enough (around 3 seconds), it will trigger `pwr_button`, to turn on or off the console core. After this happens, for it to work again, the button needs to be unpressed and pressed again for the time said

This long pressing system is more similar to how it worked in the original hardware and helps to avoid clicking it by mistake while playing

Closes #1232 