### PR TITLE
Update SDRAM refresh rate calculation constant name

### DIFF
--- a/modules/jtframe/src/jtframe/macros/macros.go
+++ b/modules/jtframe/src/jtframe/macros/macros.go
@@ -378,8 +378,8 @@ func check_colorw() {
 }
 
 func set_sdram_refresh_rate( mclk int64 ) {
-	const freq_64us = float64(128000)
-	divider := float64(mclk) / freq_64us
+	const freq_period_7812ns = float64(128000)
+	divider := float64(mclk) / freq_period_7812ns
 	bitwidth := int(math.Ceil(math.Log2(divider)))
 	Set("JTFRAME_RFSH_WC",fmt.Sprintf("%d",bitwidth))
 	Set("JTFRAME_RFSH_N", fmt.Sprintf("%d'd1",bitwidth))


### PR DESCRIPTION
I wanted to simply comment on this, but then i thought just open a PR is less noisy than a comment to track and fix.

a 128khz frequency does not match 64us anymore, and so i thought i would rename it.
Then 2 things happened:
- i have to switch to ns because is 7.8125 us
- i also thought that frequency of 78125ns sound bad so i added period in the name

Just close it if you prefer the current name.

