### PR TITLE
rungun: shadow implementation

### DIFF
--- a/cores/rungun/hdl/jtrungun_colmix.v
+++ b/cores/rungun/hdl/jtrungun_colmix.v
@@ -36,11 +36,10 @@ assign psc_op = psc_pxl[3:0]!=0;
 assign obj_op = obj_pxl[3:0]!=0;
 assign pxl[15:12]=0;
 assign pxl[11] = lrsw;
-assign pxl[ 0] = shad;
-assign pxl[10: 1] =  fix_op ?         {2'b00,fix_pxl} :
-        !psc_op || (!pri && obj_op) ? {1'b1, obj_pxl} :
-                                      {2'b01,psc_pxl};
+assign pxl[10: 0] =  fix_op ?         {2'b00,fix_pxl, 1'b0} :
+        !psc_op || (!pri && obj_op) ? {1'b1, obj_pxl, 1'b0} :
+                                      {2'b01,psc_pxl, shad};
 
-assign shad = 0; // to do
+assign shad = |shadow;
 
 endmodule


### PR DESCRIPTION
Fixes #1253 

To my understanding, the projected shadow falls only on the PSAC layer, and not on the fix or other objects

Scene examples (Before/After):

- play
![play](https://github.com/user-attachments/assets/e170c4a5-4973-4d49-b822-84426a7db8d9)
![frame_00003](https://github.com/user-attachments/assets/f2e6fd68-d534-4f2b-ab45-06bb3a970a33)

- credit
![credit](https://github.com/user-attachments/assets/78f96291-c851-4e93-8a63-200d21c4e190)
![frame_00003](https://github.com/user-attachments/assets/53c53c29-57de-4f56-862f-321fbcf17333)

- title
![title](https://github.com/user-attachments/assets/a88b63e0-74dd-48e3-8b00-4ef8240a25b8)
![frame_00003](https://github.com/user-attachments/assets/bbe1e533-d7d3-4aab-a22c-208bf2e5d743)
(In-game, the gap at the top from this scene does not exist, and it looks as it should)