### PR TITLE
slyspy midres: missing ports. Fixes compile all

### DIFF
--- a/cores/midres/hdl/jtmidres_snd.v
+++ b/cores/midres/hdl/jtmidres_snd.v
@@ -20,6 +20,7 @@
 module jtcop_snd(
     input                rst,
     input                clk,   // use 24 MHz
+    input                cen6,
     input                cen_opn,
     input                cen_opl,
 

--- a/cores/slyspy/hdl/jtslyspy_snd.v
+++ b/cores/slyspy/hdl/jtslyspy_snd.v
@@ -19,6 +19,7 @@
 module jtcop_snd(
     input                rst,
     input                clk,   // use 24 MHz
+    input                cen6,
     input                cen_opn,
     input                cen_opl,
 


### PR DESCRIPTION
Since these cores are build on the jtcop core, adding yesterday a new port for the new sound cpu made compilation fail for midres and slyspy

They don't use the T65, so just adding the missing port should be enough 