### PR TITLE
Fix for #1302

### DIFF
--- a/cores/roadf/hdl/jtroadf_main.v
+++ b/cores/roadf/hdl/jtroadf_main.v
@@ -123,7 +123,7 @@ always @(*) begin
 end
 
 function [2:0] rev3( input [6:0] x );
-    rev3 = {x[4]&x[0], x[5]&x[2], x[6]&x[1]}; // merge buttons and directions
+    rev3 = {x[4]&x[0], x[5], x[6]&x[1]}; // merge buttons and directions
 endfunction
 
 always @(posedge clk) begin

--- a/cores/track/hdl/jttrack_main.v
+++ b/cores/track/hdl/jttrack_main.v
@@ -118,7 +118,7 @@ always @(*) begin
 end
 
 function [2:0] rev3( input [6:0] x );
-    rev3 = {x[4]&x[0], x[5]&x[2], x[6]&x[1]}; // merge buttons and directions
+    rev3 = {x[4]&x[0], x[5], x[6]&x[1]}; // merge buttons and directions
 endfunction
 
 always @(posedge clk) begin


### PR DESCRIPTION
Do not mix `Up`  with `Button 2`

Fixes #1302  