### PR TITLE
cps15/wofch: missing action button

### DIFF
--- a/cores/cps15/cfg/mame2mra.toml
+++ b/cores/cps15/cfg/mame2mra.toml
@@ -13,8 +13,9 @@ delete=[{names=["Unused","Unknown"]}]
 [buttons]
 names=[
     { names="Attack,Jump" },
-    { machine="slammast",  names="Attack,Jump,Pin" },
+    { machine="slammast", names="Attack,Jump,Pin"  },
     { machine="mbombrd",  names="Grab,Attack,Jump" },
+    { machine="wofch",    names="Attack,Jump,Mega" },
 ]
 
 [header]


### PR DESCRIPTION
Related to #1301 

Adds third action button `Mega` 

<img width="1010" height="768" alt="20260108_130705-screen" src="https://github.com/user-attachments/assets/ff7ff3c9-286f-4259-83a4-185b939ffaab" />
