### PR TITLE
Outrun PCM

### DIFF
--- a/cores/outrun/hdl/jtoutrun_pcm.v
+++ b/cores/outrun/hdl/jtoutrun_pcm.v
@@ -193,7 +193,7 @@ always @(posedge clk) begin
             4: delta            <= cfg_data;
             5: loop_addr[15: 8] <= cfg_data;
             6: loop_addr[23:16] <= cfg_data;
-            7: if( cur_addr[23:16] > cfg_data ) begin
+            7: if( cur_addr[23:16] == (cfg_data + 8'b1) ) begin
                 if( cfg_en[1] ) begin
                     cfg_en[0]     <= 1; // no loop
                     cur_addr[7:0] <= 0;


### PR DESCRIPTION
In MAME, this chip adds 1 to the `end` register to do the comparison, so I've implemented it here as well

```
            uint8_t end = regs[6] + 1;
			int i;

			/* loop over samples on this channel */
			for (i = 0; i < outputs[0].samples(); i++)
			{
				int8_t v;

				/* handle looping if we've hit the end */
				if ((addr >> 16) == end)
				{
					if (regs[0x86] & 2)
					{
						regs[0x86] |= 1;
						break;
					}
					else addr = loop;
				}
```

This fixes the siren sound in Turbo Outrun (#243, #1013) while not breaking the motorbike sounds in Super Hang On (#962)