### PR TITLE
cal50: sync signals follow schematics

### DIFF
--- a/cores/cal50/hdl/jtcal50_video.v
+++ b/cores/cal50/hdl/jtcal50_video.v
@@ -112,8 +112,8 @@ jtframe_vtimer #(
     .HS_END  ( 9'd480 ),
     .HCNT_END( 9'd511 ),
     .V_START ( 9'd000 ),
-    .VS_START( 9'd252 ),
-    .VS_END  ( 9'd260 ),
+    .VS_START( 9'd253 ),
+    .VS_END  ( 9'd261 ),
     .VB_START( 9'd240 ),
     .VB_END  ( 9'd000 ),
     .VCNT_END( 9'd271 )


### PR DESCRIPTION
For #1355 

In calibr50 schematics we find:
<img width="1082" height="363" alt="image" src="https://github.com/user-attachments/assets/b5f2dd28-92e0-47ba-9468-d884024243f5" />
 But the core was generating 11-8-13 lines. This commit fixes that. Maybe this helps with the sync issues

I have also seen this in the schematics:
<img width="772" height="519" alt="image" src="https://github.com/user-attachments/assets/75c8a882-20cf-4f16-bceb-78863ad8560f" />
The core is generating horizontally 36-64-36 instead of 32-64-32. It is also defined `JTFRAME_WIDTH=376` in `macros.def` instead of 384 (as used in MAME and according to schematics), but I haven't changed this one yet, because I assumed it was intentional to reduce black borders. Should I change it back?