### PR TITLE
fix(shanon): increase audio gain

### DIFF
--- a/cores/shanon/cfg/mem.yaml
+++ b/cores/shanon/cfg/mem.yaml
@@ -3,7 +3,7 @@ include:
     core: outrun
 game: outrun
 audio:
-  gain: 1.5
+  gain: 1.25
 params:
   - { name: ROAD_START }
   - { name: FD_PROM,     value: "`FD1089_START" }

--- a/cores/shanon/cfg/mem.yaml
+++ b/cores/shanon/cfg/mem.yaml
@@ -2,6 +2,8 @@ include:
   - file: audio.yaml
     core: outrun
 game: outrun
+audio:
+  gain: 1.5
 params:
   - { name: ROAD_START }
   - { name: FD_PROM,     value: "`FD1089_START" }


### PR DESCRIPTION
## Summary
- Increase shanon audio gain to 1.25x
- Reduced from the initial 1.5x attempt after FPGA testing showed LED clipping
- Generated gains: fm=0.68, pcm=1.25

## Validation
- jtframe mem shanon -l: generated gains checked
- jtcore shanon -mrq: PASS
- Transferred release files to the shared MiSTer by the TV