### PR TITLE
grad3: objects signals to match schematics

### DIFF
--- a/cores/grad3/hdl/jtgrad3_colmix.v
+++ b/cores/grad3/hdl/jtgrad3_colmix.v
@@ -74,7 +74,7 @@ endfunction
 always @(*) begin
     case({sel})
         0: pal_addr[7:0] = {1'b0,lyrf_pxl[6:0]};
-        1: pal_addr[7:0] = {     lyro_pxl[7:0]};
+        1: pal_addr[7:0] = {lyro_pxl[8:5],lyro_pxl[3:0]};
         2: pal_addr[7:0] = {1'b0,lyra_pxl[6:0]};
         3: pal_addr[7:0] = {1'b0,lyrb_pxl[6:0]};
         default:;

--- a/cores/grad3/hdl/jtgrad3_video.v
+++ b/cores/grad3/hdl/jtgrad3_video.v
@@ -141,7 +141,7 @@ always @* begin
     lyra_addr = { lyra_col[4:2], lyra_col[0], pre_a[10:0] };
     lyrb_addr = { lyrb_col[4:2], lyrb_col[0], pre_b[10:0] };
     ocode_eff = { opal[0], ocode };
-    opal_eff  = { 1'b0, opal[6:5], 1'b1, opal[4:1] };
+    opal_eff  = { opal[7:1],1'b0 };
 end
 
 always @(posedge clk, posedge rst) begin


### PR DESCRIPTION
Connections in the schematics for 051937 in the objects page:

<img width="633" height="475" alt="image" src="https://github.com/user-attachments/assets/45e46e88-997a-4d6e-8d0c-ce11974182d5" />

<img width="576" height="346" alt="image" src="https://github.com/user-attachments/assets/3353abf1-3856-45d8-80de-32878587d266" />
