### PR TITLE
Fix Markdown links in core READMEs

### DIFF
--- a/cores/bubl/README.md
+++ b/cores/bubl/README.md
@@ -96,7 +96,7 @@ Use `git clone --recurse-submodules` in order to get all submodules when you clo
 
 # Compilation
 
-Please check [the compilation guide in JTFRAME](modules/jframe/doc/compilation.md)
+Please check [the compilation guide in JTFRAME](../../modules/jtframe/doc/compilation.md)
 
 # Credits
 

--- a/cores/castle/README.md
+++ b/cores/castle/README.md
@@ -87,7 +87,7 @@ its submodules following standard git instructions. Go to the root folder and
 type `source setprj.sh`. Now you can compile the core with `jtcore contra -mist`
 Use `-mister` or `-sidi` if appropriate.
 
-Also check the instructions in [modules/jtframe/doc/compilation.md](JTFRAME)
+Also check the instructions in [JTFRAME compilation guide](../../modules/jtframe/doc/compilation.md)
 
 # ROM file
 

--- a/cores/comsc/README.md
+++ b/cores/comsc/README.md
@@ -57,7 +57,7 @@ its submodules following standard git instructions. Go to the root folder and
 type `source setprj.sh`. Now you can compile the core with `jtcore contra -mist`
 Use `-mister` or `-sidi` if appropriate.
 
-Also check the instructions in [modules/jtframe/doc/compilation.md](JTFRAME)
+Also check the instructions in [JTFRAME compilation guide](../../modules/jtframe/doc/compilation.md)
 
 # ROM file
 

--- a/cores/contra/README.md
+++ b/cores/contra/README.md
@@ -57,7 +57,7 @@ its submodules following standard git instructions. Go to the root folder and
 type `source setprj.sh`. Now you can compile the core with `jtcore contra -mist`
 Use `-mister` or `-sidi` if appropriate.
 
-Also check the instructions in [modules/jtframe/doc/compilation.md](JTFRAME)
+Also check the instructions in [JTFRAME compilation guide](../../modules/jtframe/doc/compilation.md)
 
 # ROM file
 

--- a/cores/cps1/README.md
+++ b/cores/cps1/README.md
@@ -8,7 +8,7 @@ Capcom System 1/1.5/2 compatible verilog core for FPGA by Jose Tejada (jotego).
 
 # Original Documentation
 
-[The internet archive](www.archive.org) holds some schematics related to this work.
+[The Internet Archive](https://archive.org) holds some schematics related to this work.
 
 * [Forgotten Worlds manual](https://archive.org/details/arcademanual_forgotten-worlds/page/n15/mode/2up)
 
@@ -41,7 +41,7 @@ The _rotate screen_ OSD option is ignored for horizontal games.
 
 ## MiST
 
-You need to generate the .rom file using this (tool)[https://github.com/sebdel/mra-tools-c/tree/master/release]. Basically call it like this:
+You need to generate the .rom file using this [tool](https://github.com/sebdel/mra-tools-c/tree/master/release). Basically call it like this:
 
 `mra ghouls.mra -z rompath -A`
 
@@ -57,7 +57,7 @@ Pang! 3 and all CPS 1.5/2 games did not use DIP switches to configure the game, 
 
 # Issues
 
-Please report issues (here)[https://github.com/jotego/jtcores/issues].
+Please report issues [here](https://github.com/jotego/jtcores/issues).
 
 ## QSound Hiss
 
@@ -106,7 +106,7 @@ jedutil -view wl24b.1a gal16v8
 In order to see the equations for Willow's PAL.
 
 # Compilation
-The core is compiled using jtcore from **JTFRAME**. Follow the instructions in the README file of (JTFRAME)[https://github.com/jotego/jtcores/tree/master/modules/jtframe] and then:
+The core is compiled using jtcore from **JTFRAME**. Follow the instructions in the README file of [JTFRAME](https://github.com/jotego/jtcores/tree/master/modules/jtframe) and then:
 
 ```
 source setprj.sh

--- a/cores/cps15/README.md
+++ b/cores/cps15/README.md
@@ -8,7 +8,7 @@ Capcom System 1/1.5/2 compatible verilog core for FPGA by Jose Tejada (jotego).
 
 # Original Documentation
 
-[The internet archive](www.archive.org) holds some schematics related to this work.
+[The Internet Archive](https://archive.org) holds some schematics related to this work.
 
 * [Forgotten Worlds manual](https://archive.org/details/arcademanual_forgotten-worlds/page/n15/mode/2up)
 
@@ -41,7 +41,7 @@ The _rotate screen_ OSD option is ignored for horizontal games.
 
 ## MiST
 
-You need to generate the .rom file using this (tool)[https://github.com/sebdel/mra-tools-c/tree/master/release]. Basically call it like this:
+You need to generate the .rom file using this [tool](https://github.com/sebdel/mra-tools-c/tree/master/release). Basically call it like this:
 
 `mra ghouls.mra -z rompath -A`
 
@@ -57,7 +57,7 @@ Pang! 3 and all CPS 1.5/2 games did not use DIP switches to configure the game, 
 
 # Issues
 
-Please report issues (here)[https://github.com/jotego/jtbin/issues].
+Please report issues [here](https://github.com/jotego/jtbin/issues).
 
 ## QSound Hiss
 
@@ -98,7 +98,7 @@ jedutil -view wl24b.1a gal16v8
 In order to see the equations for Willow's PAL.
 
 # Compilation
-The core is compiled using jtcore from **JTFRAME**. Follow the instructions in the README file of (JTFRAME)[https://github.com/jotego/jtcores/tree/master/modules/jtframe] and then:
+The core is compiled using jtcore from **JTFRAME**. Follow the instructions in the README file of [JTFRAME](https://github.com/jotego/jtcores/tree/master/modules/jtframe) and then:
 
 ```
 source setprj.sh

--- a/cores/flane/README.md
+++ b/cores/flane/README.md
@@ -57,7 +57,7 @@ its submodules following standard git instructions. Go to the root folder and
 type `source setprj.sh`. Now you can compile the core with `jtcore contra -mist`
 Use `-mister` or `-sidi` if appropriate.
 
-Also check the instructions in [modules/jtframe/doc/compilation.md](JTFRAME)
+Also check the instructions in [JTFRAME compilation guide](../../modules/jtframe/doc/compilation.md)
 
 # ROM file
 

--- a/cores/kchamp/README.md
+++ b/cores/kchamp/README.md
@@ -4,7 +4,7 @@ Designed by Jose Tejada (jotego - @topapate). PCB donated by **DJ HARDRICH**.
 
 You can show your appreciation through
 * [Patreon](https://patreon.com/jotego)
-* [Paypal] (https://paypal.me/topapate)
+* [Paypal](https://paypal.me/topapate)
 
 Yes, you always wanted to have a Karate Champ arcade board at home. First you couldn't get it because your parents somehow did not understand you. Then you grow up and your wife doesn't understand you either. On top of that, an original PCB from Japan costs $500. Don't worry, MiST(er) is here to the rescue.
 

--- a/cores/kiwi/README.md
+++ b/cores/kiwi/README.md
@@ -95,7 +95,7 @@ Use `git clone --recurse-submodules` in order to get all submodules when you clo
 
 # Compilation
 
-Please check [the compilation guide in JTFRAME](modules/jframe/doc/compilation.md)
+Please check [the compilation guide in JTFRAME](../../modules/jtframe/doc/compilation.md)
 
 # Credits
 

--- a/cores/labrun/README.md
+++ b/cores/labrun/README.md
@@ -57,7 +57,7 @@ its submodules following standard git instructions. Go to the root folder and
 type `source setprj.sh`. Now you can compile the core with `jtcore contra -mist`
 Use `-mister` or `-sidi` if appropriate.
 
-Also check the instructions in [modules/jtframe/doc/compilation.md](JTFRAME)
+Also check the instructions in [JTFRAME compilation guide](../../modules/jtframe/doc/compilation.md)
 
 # ROM file
 

--- a/cores/mx5k/README.md
+++ b/cores/mx5k/README.md
@@ -57,7 +57,7 @@ its submodules following standard git instructions. Go to the root folder and
 type `source setprj.sh`. Now you can compile the core with `jtcore contra -mist`
 Use `-mister` or `-sidi` if appropriate.
 
-Also check the instructions in [modules/jtframe/doc/compilation.md](JTFRAME)
+Also check the instructions in [JTFRAME compilation guide](../../modules/jtframe/doc/compilation.md)
 
 # ROM file
 


### PR DESCRIPTION
## Summary

Fix malformed Markdown links in several core README files.

## Changes

- Add explicit "https://" scheme for Internet Archive links.
- Fix reversed Markdown link syntax.
- Fix stale "modules/jframe" path typo to "modules/jtframe".
- Fix local JTFRAME compilation guide links.
- Fix a PayPal Markdown link with an extra space.

## Notes

This is a docs-only change. It does not modify HDL, gameplay behavior, audio behavior, ROM handling, configuration semantics, or build flow.