### PR TITLE
ci: skip simunit & compile-all on draft PRs

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -2,6 +2,9 @@ name: Pull Request checks
 
 on:
   pull_request:
+    # ready_for_review makes the heavy jobs fire the moment a PR leaves draft;
+    # the other three are the defaults, which must be restated once types is set.
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: ${{ github.head_ref || github.ref }}-pr-checks
@@ -21,10 +24,15 @@ jobs:
     secrets: inherit
 
   unit_simulations:
+    # Skip the 63-job sim fan-out on draft PRs. Safe here because this
+    # workflow only runs on pull_request, so the draft field always exists.
+    if: github.event.pull_request.draft == false
     uses: ./.github/workflows/simunit.yaml
     secrets: inherit
 
   compile_all:
+    # Skip the full compile (74 cores x 3 toolchains) on draft PRs.
+    if: github.event.pull_request.draft == false
     needs:
       - beta_checks
       - framework_tests

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -22,7 +22,6 @@ jobs:
     secrets: inherit
 
   unit_simulations:
-    if: github.event.pull_request.draft == false
     uses: ./.github/workflows/simunit.yaml
     secrets: inherit
 

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -2,8 +2,6 @@ name: Pull Request checks
 
 on:
   pull_request:
-    # ready_for_review makes the heavy jobs fire the moment a PR leaves draft;
-    # the other three are the defaults, which must be restated once types is set.
     types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
@@ -24,14 +22,11 @@ jobs:
     secrets: inherit
 
   unit_simulations:
-    # Skip the 63-job sim fan-out on draft PRs. Safe here because this
-    # workflow only runs on pull_request, so the draft field always exists.
     if: github.event.pull_request.draft == false
     uses: ./.github/workflows/simunit.yaml
     secrets: inherit
 
   compile_all:
-    # Skip the full compile (74 cores x 3 toolchains) on draft PRs.
     if: github.event.pull_request.draft == false
     needs:
       - beta_checks


### PR DESCRIPTION
## What

Gate the two expensive PR jobs — `unit_simulations` (simunit) and `compile_all` — behind `github.event.pull_request.draft == false`, and add `ready_for_review` to the trigger types.

## Why — concurrency & runner time

Today a draft PR runs the **full** PR suite on every push. The gate stage (`beta-checks + framework + linter + simunit`) plus `compile_all` is a lot of work, and the two heavy jobs fan out hard:

| Job | Parallel fan-out | Per-job work |
|---|---|---|
| `compile_all` | ~222 jobs (74 cores × 3 toolchains) | Quartus synthesis in Docker |
| `unit_simulations` | ~63 jobs (one container per `.simunit` folder) | Verilator sim in Docker |
| linter / framework / beta-checks | 1 each | cheap |

GitHub-hosted runners give us a **capped concurrency pool** (~20 concurrent Linux jobs on the free tier). Those 63 + 222 jobs don't run at once — they **queue and drain**, monopolising the pool and delaying *other* PRs and the nightly `compile-all`/sim/lint runs. `jtcores` is public so the minutes themselves are free, but the **concurrency contention is the real cost**, and the moment any equivalent work runs on a private repo those minutes are metered and billed.

Draft PRs are work-in-progress by definition — paying the full ~285-job cost on every WIP push is waste. After this change, draft iterations only run the three cheap checks; the heavy jobs run once the PR is marked ready.

## How

- `if: github.event.pull_request.draft == false` on `unit_simulations` and `compile_all`.
- The guard lives **only in `pull-request.yaml`**, the sole workflow triggered by `pull_request`, so the draft field is always present. `push` / `schedule` / `repository_dispatch` / `workflow_dispatch` call `simunit.yaml` and `compile-all.yaml` **directly** and are unaffected — no risk of gating a non-PR event whose payload lacks `pull_request`.
- `compile_all` keeps its `needs:` gate; a custom `if` does not bypass `needs` success (only `always()` would), so it still requires the four checks **and** non-draft.
- Added `ready_for_review` to `types` so the heavy jobs fire the instant a PR leaves draft instead of waiting for the next push. Setting `types` explicitly requires restating the prior defaults (`opened`, `synchronize`, `reopened`).

## Behavior summary

- **Draft PR (open/push):** beta-checks + framework + linter only.
- **Mark "Ready for review":** simunit + compile-all fire immediately.
- **Ready PR push:** full suite, as before.
- **push / schedule / dispatch:** unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
