### PR TITLE
jtseed: use core name specified in macros.def to find rbf

### DIFF
--- a/modules/jtframe/src/jtutil/cmd/seed.go
+++ b/modules/jtframe/src/jtutil/cmd/seed.go
@@ -56,6 +56,7 @@ type seed_config struct {
 type seed_release struct {
 	core   string
 	target string
+	rbf    string
 }
 
 type seed_job struct {
@@ -175,6 +176,7 @@ func (cfg *seed_config) prepare() error {
 	}
 	cfg.release = info
 	cfg.load_core_macros()
+	cfg.release.rbf = strings.ToLower(macros.Get("CORENAME"))
 	cfg.nosta = macros.IsSet("JTFRAME_NOSTA")
 	cfg.easy_sta = macros.IsSet("JTFRAME_EASY_STA")
 	cfg.append_nosta_undef()
@@ -454,7 +456,7 @@ func get_jtroot() (string, error) {
 
 func (info seed_release) source_rbf(output string) string {
 	base := output
-	name := "jt" + info.core + ".rbf"
+	name := info.rbf_name() + ".rbf"
 	if info.is_mister_target() || info.target == "neptuno" {
 		base = filepath.Join(base, "output_files")
 	}
@@ -470,9 +472,16 @@ func (info seed_release) release_rbf() string {
 		return ""
 	}
 	if info.target == "pocket" {
-		return filepath.Join(root, "release", "pocket", "raw", "Cores", "jotego."+info.core, "jt"+info.core+".rbf_r")
+		return filepath.Join(root, "release", "pocket", "raw", "Cores", "jotego."+info.core, info.rbf_name()+".rbf_r")
 	}
-	return filepath.Join(root, "release", info.target, "jt"+info.core+".rbf")
+	return filepath.Join(root, "release", info.target, info.rbf_name()+".rbf")
+}
+
+func (info seed_release) rbf_name() string {
+	if info.rbf != "" {
+		return info.rbf
+	}
+	return "jt" + info.core
 }
 
 func (info seed_release) is_mister_target() bool {

--- a/modules/jtframe/src/jtutil/cmd/seed_test.go
+++ b/modules/jtframe/src/jtutil/cmd/seed_test.go
@@ -326,6 +326,25 @@ func Test_prepare_keeps_long_target_shortcut(t *testing.T) {
 	}
 }
 
+func Test_prepare_uses_target_core_name_for_rbf_paths(t *testing.T) {
+	root := setup_seed_macro_tree(t, "ngp", "CORENAME=JTNGP\n[mister]\nCORENAME=NeoGeoPocket\n")
+	cfg := &seed_config{jtcore_args: []string{"ngp", "--target", "mister"}}
+	e := cfg.prepare()
+	if e != nil {
+		t.Fatal(e)
+	}
+	if cfg.release.rbf != "neogeopocket" {
+		t.Fatalf("unexpected RBF name: %#v", cfg.release)
+	}
+	builddir := filepath.Join(root, "cores", "ngp", "seed", "mister", "0", "build")
+	if got := cfg.release.source_rbf(builddir); got != filepath.Join(builddir, "output_files", "neogeopocket.rbf") {
+		t.Fatalf("unexpected source path: %s", got)
+	}
+	if got := cfg.release.release_rbf(); got != filepath.Join(root, "release", "mister", "neogeopocket.rbf") {
+		t.Fatalf("unexpected release path: %s", got)
+	}
+}
+
 func Test_run_parallel_one_uses_seed_output(t *testing.T) {
 	root := setup_seed_macro_tree(t, "gng", "CORENAME=jtgng\n")
 	install_fake_jtcore(t, 0)


### PR DESCRIPTION
This change is needed because, currently, MiSTer's `neogeopocket.rbf` is not being saved in `Compile all` because `jtseed` looks for `jtngp.rbf` even though another`CORENAME` is specified in `macros.def`. 

This PR fixes this