### PR TITLE
[codex] fix simson Vendetta audio balance

### DIFF
--- a/cores/simson/cfg/mem.yaml
+++ b/cores/simson/cfg/mem.yaml
@@ -11,14 +11,12 @@ clocks:
         - cen_fm
         - cen_fm2
 audio:
+  gain: 0.97
   rsum: 50k
   channels:
     # both FM and PCM are mixed inside K053260, then converted with the same YM3012 DAC
     # the 0.033MM capacitor in sch. has a 333K mark (physical device). 33nF must be right
-    # but 985 Ohm and 33nF is just too heavy damping, especially for the FM part that does
-    # not need an antialising filter. So I am using a much lighter 1nF instead that will
-    # let users hear the FM music better
-    - { name: snd, module: jt053260, rsum: 50k, rc: [ { r: 1rout, c: 2.2n }, { r: 985, c: 1n } ]}
+    - { name: snd, module: jt053260, rsum: 50k, rc: [ { r: 1rout, c: 2.2n }, { r: 985, c: 33n } ]}
 sdram:
   banks:
     - buses:

--- a/cores/simson/hdl/jtsimson_sound.v
+++ b/cores/simson/hdl/jtsimson_sound.v
@@ -198,7 +198,7 @@ jt51 u_jt51(
     .xright     (           )
 );
 /* verilator tracing_off */
-jt053260 u_pcm(
+jt053260 #(.ADPCM_SAT(4'b0000),.AUX_MODE_EN(0)) u_pcm(
     .rst        ( rst_z80   ),
     .clk        ( clk       ),
     .cen        ( cen_fm    ),

--- a/modules/jt053260/hdl/jt053260.v
+++ b/modules/jt053260/hdl/jt053260.v
@@ -16,7 +16,7 @@
     Version: 1.0
     Date: 14-4-2023 */
 
-module jt053260(
+module jt053260#(parameter [3:0] ADPCM_SAT=4'hF, parameter AUX_MODE_EN=1)(
     input                    rst,
     input                    clk,
     input                    cen,
@@ -95,7 +95,7 @@ assign mmr_we  = {4{ cs & ~wr_n & mmr_en }} &
 assign tst_nx  = tst_rd & ~tst_rdl;
 assign left_en = sum_en[4:0];
 assign right_en={sum_en[5],sum_en[3:0]};
-assign aux_en  = mode[3:2];
+assign aux_en  = AUX_MODE_EN ? mode[3:2] : 2'b11;
 `ifdef SIMULATION
 assign tim2_enb= test_2b[3]; // it should disable tim2 when high. Not connected for now
 wire any_wr = cs & ~wr_n;
@@ -234,7 +234,7 @@ always @* begin
     pan3_r = pan_dec_r( ch3_pan );
 end
 
-jt053260_channel #(.TESTRD(1)) u_ch0(
+jt053260_channel #(.TESTRD(1),.ADPCM_SAT(ADPCM_SAT[0])) u_ch0(
     .rst      ( rst         ),
     .clk      ( clk         ),
     .cen      ( cen         ),
@@ -263,7 +263,7 @@ jt053260_channel #(.TESTRD(1)) u_ch0(
     .snd_r    ( ch0_snd_r   )
 );
 
-jt053260_channel u_ch1(
+jt053260_channel #(.ADPCM_SAT(ADPCM_SAT[1])) u_ch1(
     .rst      ( rst         ),
     .clk      ( clk         ),
     .cen      ( cen         ),
@@ -292,7 +292,7 @@ jt053260_channel u_ch1(
     .snd_r    ( ch1_snd_r   )
 );
 
-jt053260_channel u_ch2(
+jt053260_channel #(.ADPCM_SAT(ADPCM_SAT[2])) u_ch2(
     .rst      ( rst         ),
     .clk      ( clk         ),
     .cen      ( cen         ),
@@ -321,7 +321,7 @@ jt053260_channel u_ch2(
     .snd_r    ( ch2_snd_r   )
 );
 
-jt053260_channel u_ch3(
+jt053260_channel #(.ADPCM_SAT(ADPCM_SAT[3])) u_ch3(
     .rst      ( rst         ),
     .clk      ( clk         ),
     .cen      ( cen         ),

--- a/modules/jt053260/hdl/jt053260_channel.v
+++ b/modules/jt053260/hdl/jt053260_channel.v
@@ -16,7 +16,7 @@
     Version: 1.0
     Date: 14-4-2023 */
 
-module jt053260_channel#(parameter TESTRD=0)(
+module jt053260_channel#(parameter TESTRD=0, parameter ADPCM_SAT=1)(
     input                    rst,
     input                    clk,
     input                    cen,
@@ -168,7 +168,7 @@ always @(posedge clk) begin
                             end
                         end
                     end
-                    pre_snd <= adpcm_en ? adpcm_lim : rom_data;
+                    pre_snd <= adpcm_en ? (ADPCM_SAT ? adpcm_lim : pre_snd + kadpcm) : rom_data;
                 end
             end
         end


### PR DESCRIPTION
## Summary
- Restore the Simpsons/Vendetta K053260 auxiliary FM mix behavior for the simson core
- Keep the ADPCM saturation path available by parameter, but use the 94364a5-style ADPCM accumulation for simson
- Restore the 33n RC pole and set simson audio gain to 0.97 to avoid startup peak LED flashes

## Root Cause
Vendetta sounded muted/muffled in the 2026-06-11 9c688b8 build compared with the 2025-08-09 94364a5 build. The relevant behavioral difference was that K053260 AUX/FM mixing became gated by mode[3:2]. For simson/Vendetta this can drop the FM contribution, making the output sound muted. The PR keeps the newer behavior as the default for shared jt053260 users and opts simson into the older always-mixed AUX behavior.

## Validation
- jtframe mem simson -l from cores/simson/ver/vendetta: generated g0 = 8'h7C (0.97)
- jtcore simson -mrq: PASS, 0 errors, 410 warnings
- Tested on La MiSTer TV during development: Vendetta audio no longer sounded muted; The Simpsons had no warning LED flashes or clipping at gain 0.95, then gain was raised to 0.97 for final test build