### PR TITLE
fix(): Sprites wrap around

### DIFF
--- a/cores/ddrbl/hdl/jtddrbl_k005885.v
+++ b/cores/ddrbl/hdl/jtddrbl_k005885.v
@@ -4,14 +4,34 @@
 //  time-shared ROM bus). Instantiated twice: E16=FG/gfx1, H16=BG/gfx2; each
 //  emits COL[4:0] into jtddrbl_colmix.
 //----------------------------------------------------------------------------
-//  Portions derived from the MIT-licensed k005885.sv by Ace. MIT notice:
+//  This file contains portions derived from k005885.sv by Ace, used under the
+//  MIT License. The original copyright notice and MIT permission notice are
+//  reproduced below in full, as that license requires:
+//
+//    Copyright (C) 2020, 2022 Ace
+//
 //    Permission is hereby granted, free of charge, to any person obtaining a
-//    copy of this software and associated documentation files (the
-//    "Software"), to deal in the Software without restriction... The above
-//    copyright notice and this permission notice shall be included in all
-//    copies or substantial portions of the Software. THE SOFTWARE IS
-//    PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
-//  JTCORES integration is GPL-3 (see jtcores LICENSE).
+//    copy of this software and associated documentation files (the "Software"),
+//    to deal in the Software without restriction, including without limitation
+//    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+//    and/or sell copies of the Software, and to permit persons to whom the
+//    Software is furnished to do so, subject to the following conditions:
+//
+//    The above copyright notice and this permission notice shall be included in
+//    all copies or substantial portions of the Software.
+//
+//    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+//    DEALINGS IN THE SOFTWARE.
+//
+//  The MIT-derived portion is the CPU register file, interrupt generators and
+//  internal-RAM address decode. The JTFRAME integration, video timing, and the
+//  tilemap/sprite datapath (here and in jtddribble_scroll.v / jtddribble_obj.v)
+//  are original work, licensed GPL-3 (see jtcores LICENSE).
 //
 //  Author: Andrea Bogazzi <andreabogazzi79@gmail.com>
 //============================================================================
@@ -97,6 +117,7 @@ wire cen_6m = pxl_cen;     // chip pixel clock
 //------------------------------------------------------------------------
 wire [8:0] vt_H, vt_vdump;
 wire       vt_lhbl, vt_lvbl, vt_hs, vt_vs;
+
 jtframe_vtimer #(
     .HCNT_END ( 9'd383 ),
     .HB_START ( 9'd269 ),   // LHBL=0 at 269 -> visible 14..269 (256 px)

--- a/cores/ddrbl/hdl/jtddrbl_obj.v
+++ b/cores/ddrbl/hdl/jtddrbl_obj.v
@@ -70,7 +70,7 @@ reg  [15:0] spr_word;      // fetched gfx word (4 px)
 reg  [ 1:0] spr_dn;        // nibble counter for the dump
 reg         old_hblk_obj;
 reg         line_we;
-reg  [ 7:0] line_addr;
+reg  [ 8:0] line_addr;
 reg  [ 3:0] line_data;     // OCD (looked-up sprite colour), 0 = transparent
 
 assign obj_rd_addr = { 3'd0, obj_base } + { 9'd0, obj_byte };
@@ -97,10 +97,7 @@ wire [16:0] spr_local = { eff_num, row_sp[3], spr_hp[3], row_sp[2:0], spr_hp[2] 
 assign rom_addr = OBJSTART | ({1'b0, spr_local} & OBJMASK);
 assign rom_cs   = obj_run && (obj_st==4'd6 || obj_st==4'd7);
 
-// Screen column for the write. No wrap: a column >=256 is off-screen (dropped).
-// h-flip mirrors the column within the sprite.
 wire [ 5:0] hp_scr   = s_fx ? (obj_w - 6'd1 - spr_hp) : spr_hp;
-// -1: the sprite layer measured 1px right of MAME; shift it left to align.
 wire [ 9:0] full_col = ({1'b0, s_xpos} + {4'd0, hp_scr}) - 10'd1;
 
 wire [3:0] dump_nibble = spr_word[15:12];                 // OCB (sprite pixel)
@@ -146,9 +143,8 @@ always @(posedge clk) begin
         4'd6: obj_st<=4'd7;                                    // issue gfx fetch
         4'd7: if (rom_ok) begin spr_word<={RDU,RDL}; spr_dn<=2'd0; obj_st<=4'd8; end
         4'd8: begin                                            // dump 4 px (high-nibble first)
-                  // write only if on-screen and opaque (OCD!=0)
-                  line_we   <= ~|full_col[9:8] & (OCD != 4'd0);
-                  line_addr <= full_col[7:0];
+                  line_we   <= (OCD != 4'd0);
+                  line_addr <= full_col[8:0];
                   line_data <= OCD;                        // looked-up sprite colour
                   spr_word  <= { spr_word[11:0], 4'd0 };
                   spr_hp    <= spr_hp + 6'd1;
@@ -166,11 +162,10 @@ always @(posedge clk) begin
 end
 
 // Sprite line buffer (jtframe_obj_buffer, double-buffered, erase-on-read).
-wire [7:0] obj_dcol = h_cnt[7:0] - HB_OPEN[7:0];   // display read column
-// Toggle the double buffer at h_cnt 2 (the post-obj_win / pre-display gap) so the
-// display read and the obj_win write always hit opposite banks.
+wire [8:0] obj_dcol = { 1'b0, h_cnt[7:0] - HB_OPEN[7:0] };
+// Toggle the double buffer at h_cnt 2 so display read and obj_win write hit opposite banks.
 wire objbuf_lhbl = (h_cnt < 9'd2) || (h_cnt >= 9'd14);
-jtframe_obj_buffer #(.DW(4), .AW(8), .ALPHA(4'h0)) u_objbuf(
+jtframe_obj_buffer #(.DW(4), .AW(9), .ALPHA(4'h0)) u_objbuf(
     .clk     ( clk            ),
     .LHBL    ( objbuf_lhbl    ),
     .flip    ( 1'b0           ),


### PR DESCRIPTION
This PR address back the license for the @ace portion of code, as explained by @Boogerman, and it fixes the sprite disappearing from the left too soon.

This was already working before moving to jt primitives, but during the conversion was missed.

The upper screenshot is MAME
The below screenshot is the core in simulation with the playfield wrong because i can't sim properly.

<img width="512" height="1344" alt="image" src="https://github.com/user-attachments/assets/c2a5fb13-33fd-4d20-b58a-89fee2834eb9" />

You can see in mame those players are missing entirely
<img width="39" height="93" alt="image" src="https://github.com/user-attachments/assets/4de1e72b-8789-474d-9d5d-22acada2e7dc" />

