### PR TITLE
fix(): Double dribble sprite glitches

### DIFF
--- a/cores/ddrbl/cfg/mem.yaml
+++ b/cores/ddrbl/cfg/mem.yaml
@@ -17,7 +17,8 @@ audio:
   rc:   { r: 1k, c: 10n }
   channels:
     - { name: fm,   module: jt03_fm, rsum: 5.3k, rc: [{ r: 0.81k, c: 33n }] }
-    # psg rsum was 20k from the schematic; raised to 56.4k for ~-9 dB attenuation.
+    # psg rsum was 20k from the schematic; raised to 56.4k for ~-9 dB attenuation
+    # (gain ~ 1/rsum, 20/56.4 = 0.355 = -9 dB) — found necessary by ear vs FM/VLM.
     - { name: psga, data_width: 8, unsigned: true, rsum: 56.4k, rc_en: true, dcrm: true, rc: [{ r: 0.78k, c: 150n }] }
     - { name: psgb, data_width: 8, unsigned: true, rsum: 56.4k, rc_en: true, dcrm: true, rc: [{ r: 0.78k, c: 150n }] }
     - { name: psgc, data_width: 8, unsigned: true, rsum: 56.4k, rc_en: true, dcrm: true, rc: [{ r: 0.78k, c: 150n }] }
@@ -48,12 +49,18 @@ sdram:
           offset: VLM_OFFSET
 
     - buses:
-        - name: gfx1
+        - name: gfx1          # chip1 tiles (RA16=0 half)
+          addr_width: 18
+          data_width: 32
+        - name: gfx1obj       # chip1 sprites (high half) — own slot, same region
           addr_width: 18
           data_width: 32
 
     - buses:
-        - name: gfx2
+        - name: gfx2          # chip2 tiles (RA16=0 half)
+          addr_width: 19
+          data_width: 32
+        - name: gfx2obj       # chip2 sprites (RA16=1 half) — own slot, same region
           addr_width: 19
           data_width: 32
 

--- a/cores/ddrbl/cfg/mem.yaml
+++ b/cores/ddrbl/cfg/mem.yaml
@@ -18,7 +18,6 @@ audio:
   channels:
     - { name: fm,   module: jt03_fm, rsum: 5.3k, rc: [{ r: 0.81k, c: 33n }] }
     # psg rsum was 20k from the schematic; raised to 56.4k for ~-9 dB attenuation
-    # (gain ~ 1/rsum, 20/56.4 = 0.355 = -9 dB) — found necessary by ear vs FM/VLM.
     - { name: psga, data_width: 8, unsigned: true, rsum: 56.4k, rc_en: true, dcrm: true, rc: [{ r: 0.78k, c: 150n }] }
     - { name: psgb, data_width: 8, unsigned: true, rsum: 56.4k, rc_en: true, dcrm: true, rc: [{ r: 0.78k, c: 150n }] }
     - { name: psgc, data_width: 8, unsigned: true, rsum: 56.4k, rc_en: true, dcrm: true, rc: [{ r: 0.78k, c: 150n }] }

--- a/cores/ddrbl/hdl/jtddrbl_game.v
+++ b/cores/ddrbl/hdl/jtddrbl_game.v
@@ -146,6 +146,16 @@ jtddrbl_video u_video(
     .gfx2_cs        ( gfx2_cs        ),
     .gfx2_data      ( gfx2_data      ),
     .gfx2_ok        ( gfx2_ok        ),
+
+    .gfx1obj_addr   ( gfx1obj_addr   ),
+    .gfx1obj_cs     ( gfx1obj_cs     ),
+    .gfx1obj_data   ( gfx1obj_data   ),
+    .gfx1obj_ok     ( gfx1obj_ok     ),
+
+    .gfx2obj_addr   ( gfx2obj_addr   ),
+    .gfx2obj_cs     ( gfx2obj_cs     ),
+    .gfx2obj_data   ( gfx2obj_data   ),
+    .gfx2obj_ok     ( gfx2obj_ok     ),
     // interrupts (chip 1 fans to both CPUs)
     .k5885_1_fir_n  ( fir_n          ),
     .k5885_1_irq_n  ( irq_n          ),

--- a/cores/ddrbl/hdl/jtddrbl_k005885.v
+++ b/cores/ddrbl/hdl/jtddrbl_k005885.v
@@ -63,12 +63,16 @@ module jtddrbl_k005885 #(
     output             NNMI,
     output             NFIR,
 
-    // Graphics-ROM bus. The chip emits R[15:0]; RA16/RA17 (made off-chip by the
-    // LS74 chain on the PCB) are exposed so game.v drives the gfx-region MSBs.
-    output             RA17,
-    output             RA16,
-    output     [15:0]  R,
-    input      [31:0]  RD,           // 32-bit packed gfx row (jtframe_scroll path)
+    // Graphics-ROM bus — independent tile and sprite SDRAM slots
+    // (mem.yaml gfx{1,2}=tiles, gfx{1,2}obj=sprites).
+    output     [15:0]  scr_addr,     // tile gfx word address
+    output             scr_cs,
+    input      [31:0]  scr_data,     // 32-bit packed gfx row (jtframe_scroll path)
+    input              scr_ok,
+    output     [16:0]  obj_addr,     // sprite gfx word address (= spr_rom_addr[17:1])
+    output             obj_cs,
+    input      [31:0]  obj_data,
+    input              obj_ok,
 
     output     [ 3:0]  OCF,OCB,
     input      [ 3:0]  OCD,
@@ -81,10 +85,6 @@ module jtddrbl_k005885 #(
     input              clk,
     input              pxl_cen,             // pixel-rate clock-enable (clk/8)
     input              cpu_cen,             // CPU-rate clock-enable
-
-    // SDRAM ready-handshake (graphics ROM fetch)
-    input              rom_ok,
-    output             rom_cs,
 
     // Video blanking (active high) + hsync (active low)
     output             HBLK,
@@ -117,7 +117,6 @@ wire cen_6m = pxl_cen;     // chip pixel clock
 //------------------------------------------------------------------------
 wire [8:0] vt_H, vt_vdump;
 wire       vt_lhbl, vt_lvbl, vt_hs, vt_vs;
-
 jtframe_vtimer #(
     .HCNT_END ( 9'd383 ),
     .HB_START ( 9'd269 ),   // LHBL=0 at 269 -> visible 14..269 (256 px)
@@ -287,17 +286,18 @@ jtddrbl_scroll #( .LAYER_BG(LAYER_BG) ) u_scroll(
     .vram_dout( vram_scn_dout    ),
     .rom_cs   ( scroll_rom_cs    ),
     .rom_addr ( scroll_rom_addr  ),
-    .rom_data ( RD               ),                 // 32-bit packed gfx
-    .rom_ok   ( rom_ok           ),
+    .rom_data ( scr_data         ),                 // 32-bit packed gfx (tile slot)
+    .rom_ok   ( scr_ok           ),
     .pxl      ( sc_pxl           )
 );
 
 //------------------------------------------------------------------------
-//  Sprite engine — jtddrbl_obj on the 32-bit gfx bus. Time-shares the gfx
-//  ROM with the tilemap (sprites in obj_win h_cnt>=272, tiles otherwise). OBJ
-//  list = vblank snapshot (sprite frame-buffer 1-frame delay).
+//  Sprite engine — jtddrbl_obj on its OWN gfx slot (gfx*obj).
+//  OBJ list = vblank snapshot (sprite frame-buffer 1-frame delay).
 //------------------------------------------------------------------------
-wire obj_win = h_cnt >= 9'd272;
+// Sprite-scan window: whole line, starting a few pixels after the line-buffer
+// bank toggle (objbuf_lhbl falls at h_cnt 2) to avoid a first-write/toggle race.
+wire obj_win = h_cnt >= 9'd8;
 
 localparam OBJ_AW = 9;                  // OBJ list <=320 B -> 512-entry shadow
 wire [OBJ_AW-1:0] dma_addr;
@@ -321,7 +321,7 @@ assign vram_scn_addr = dma_we ? { 1'b1, 3'd0, dma_addr } : scroll_vram_addr;
 wire [17:0] spr_rom_addr;
 wire        spr_rom_cs;
 wire        spr_half = spr_rom_addr[0];
-wire [15:0] spr_gfx16 = spr_half ? RD[31:16] : RD[15:0];
+wire [15:0] spr_gfx16 = spr_half ? obj_data[31:16] : obj_data[15:0];
 wire [3:0]  obj_pxl;
 jtddrbl_obj #(
     .LAYER_BG     ( LAYER_BG     ),
@@ -344,16 +344,17 @@ jtddrbl_obj #(
     .OCF          ( OCF            ),
     .OCB          ( OCB            ),
     .OCD          ( OCD            ),
-    .rom_ok       ( rom_ok         ),
+    .rom_ok       ( obj_ok         ),
     .obj_pxl      ( obj_pxl        )
 );
 
-//  gfx ROM bus: sprites during obj_win, tilemap otherwise. RD is 32-bit; the
-//  sprite addresses 32-bit words via spr_rom_addr[16:1] (bit[0] = the half).
-assign R      = obj_win ? spr_rom_addr[16:1] : scroll_rom_addr;
-assign RA16   = obj_win ? spr_rom_addr[17]   : 1'b0;
-assign RA17   = 1'b0;
-assign rom_cs = obj_win ? spr_rom_cs : scroll_rom_cs;
+//  gfx ROM buses: tile and sprite fetches drive independent SDRAM slots.
+//  spr_rom_addr[0] is the 16-bit half selector, dropped from the word address
+//  (obj_data returns the full 32-bit word).
+assign scr_addr = scroll_rom_addr;
+assign scr_cs   = scroll_rom_cs;
+assign obj_addr = spr_rom_addr[17:1];
+assign obj_cs   = spr_rom_cs;
 
 // COL out: opaque sprite over tile.
 assign pxl_out = { 2'b00, (obj_pxl != 4'h0) ? { 1'b0, obj_pxl } : { 1'b1, sc_pxl[3:0] } };

--- a/cores/ddrbl/hdl/jtddrbl_obj.v
+++ b/cores/ddrbl/hdl/jtddrbl_obj.v
@@ -5,10 +5,6 @@
 //  up the sprite colour (I15 256x4 PROM on chip 2 / 1:1 on chip 1) and fills a
 //  jtframe_obj_buffer that is read back at display time as obj_pxl (0=transp.).
 //
-//  The VRAM-scan and gfx-ROM ports are time-shared with the tilemap engine in
-//  the parent chip: this module owns them only during obj_win (h_cnt>=272); the
-//  parent muxes obj_rd_addr / rom_addr onto the shared buses.
-//
 //  Author: Andrea Bogazzi <andreabogazzi79@gmail.com>
 //  JTCORES integration is GPL-3 (see jtcores LICENSE).
 //============================================================================
@@ -27,17 +23,17 @@ module jtddrbl_obj #(
     // video timing from the parent chip
     input      [ 8:0]  h_cnt,
     input      [ 8:0]  v_cnt,
-    input              obj_win,          // sprite window (h_cnt>=272)
+    input              obj_win,          // sprite window
     input              hblank,           // active-high horizontal blank (display gate)
 
-    // OBJ-list scan on the shared VRAM render port (parent muxes when obj_win)
+    // OBJ-list scan
     output     [11:0]  obj_rd_addr,
     input      [ 7:0]  vram_scn_dout,
 
     // External PROM
     output     [ 3:0]  OCF,OCB,
     input      [ 3:0]  OCD,
-    // sprite gfx fetch on the shared gfx-ROM bus (parent muxes when obj_win)
+    // sprite gfx fetch on the gfx-ROM bus
     output     [17:0]  rom_addr,
     output             rom_cs,
     input      [ 7:0]  RDU,

--- a/cores/ddrbl/hdl/jtddrbl_video.v
+++ b/cores/ddrbl/hdl/jtddrbl_video.v
@@ -40,6 +40,15 @@ module jtddrbl_video(
     output              gfx2_cs,
     input      [31:0]   gfx2_data,
     input               gfx2_ok,
+    // sprite gfx slots (own SDRAM bus per chip)
+    output     [17:2]   gfx1obj_addr,
+    output              gfx1obj_cs,
+    input      [31:0]   gfx1obj_data,
+    input               gfx1obj_ok,
+    output     [18:2]   gfx2obj_addr,
+    output              gfx2obj_cs,
+    input      [31:0]   gfx2obj_data,
+    input               gfx2obj_ok,
 
     // Interrupts — chip 1 fans NFIR/NIRQ/NNMI to BOTH CPUs (game.v applies the
     // NFIR->IRQ / NIRQ->FIRQ swap).
@@ -99,6 +108,13 @@ wire        k5885_1_HBLK, k5885_1_VBLK, k5885_1_NHSY, k5885_1_NYSY;
 wire [ 3:0] gfx2_ocf, gfx2_ocb, gfx2_ocd;
 wire [ 3:0] gfx1_ocb;
 
+// gfx-slot address adapters: chip1's obj_addr top bit is always 0 (fits gfx1's
+// 16-bit slot); chip2's tile addr is the low half (RA16=0) of its 17-bit slot.
+wire [16:0] k1_obj_addr;
+wire [15:0] k2_scr_addr;
+assign gfx1obj_addr = k1_obj_addr[15:0];
+assign gfx2_addr    = { 1'b0, k2_scr_addr };
+
 assign LHBL = ~k5885_1_HBLK;
 assign LVBL = ~k5885_1_VBLK;
 assign HS   = ~k5885_1_NHSY;
@@ -123,17 +139,18 @@ jtddrbl_k005885 #(
     .NIRQ       ( k5885_1_irq_n   ),
     .NNMI       ( k5885_1_nmi_n   ),
     .NFIR       ( k5885_1_fir_n   ),
-    // gfx ROM
-    .R          ( gfx1_addr[17:2]),
-    .RA16       (                ),
-    .RA17       (                ),
-    .RD         ( gfx1_data      ),
+    // gfx ROM — tile slot (gfx1) + sprite slot (gfx1obj)
+    .scr_addr   ( gfx1_addr[17:2]),
+    .scr_cs     ( gfx1_cs        ),
+    .scr_data   ( gfx1_data      ),
+    .scr_ok     ( gfx1_ok        ),
+    .obj_addr   ( k1_obj_addr    ),
+    .obj_cs     ( gfx1obj_cs     ),
+    .obj_data   ( gfx1obj_data   ),
+    .obj_ok     ( gfx1obj_ok     ),
     .OCF        (                ),
     .OCB        ( gfx1_ocb       ),
     .OCD        ( gfx1_ocb       ),
-
-    .rom_cs     ( gfx1_cs        ),
-    .rom_ok     ( gfx1_ok        ),
     // sync — chip 1 owns the framework's video timing
     .NHSY       ( k5885_1_NHSY   ),
     .NYSY       ( k5885_1_NYSY   ),
@@ -166,15 +183,18 @@ jtddrbl_k005885 #(
     .NRD        ( ~main_rnw      ),
     .NEXR       ( 1'b1           ),
     .NIRQ(), .NNMI(), .NFIR(),    // chip 2 interrupts unused (chip 1 drives both CPUs)
-    .R          ( gfx2_addr[17:2]),
-    .RA16       ( gfx2_addr[18]  ),
-    .RA17       (                ),
-    .RD         ( gfx2_data      ),
+    // gfx ROM — tile slot (gfx2) + sprite slot (gfx2obj)
+    .scr_addr   ( k2_scr_addr    ),
+    .scr_cs     ( gfx2_cs        ),
+    .scr_data   ( gfx2_data      ),
+    .scr_ok     ( gfx2_ok        ),
+    .obj_addr   ( gfx2obj_addr   ),
+    .obj_cs     ( gfx2obj_cs     ),
+    .obj_data   ( gfx2obj_data   ),
+    .obj_ok     ( gfx2obj_ok     ),
     .OCF        ( gfx2_ocf       ),
     .OCB        ( gfx2_ocb       ),
     .OCD        ( gfx2_ocd       ),
-    .rom_cs     ( gfx2_cs        ),
-    .rom_ok     ( gfx2_ok        ),
     .vram_cpu_addr ( vram2_cpu_addr ),
     .vram_cpu_din  ( vram2_cpu_din  ),
     .vram_cpu_we   ( vram2_cpu_we   ),


### PR DESCRIPTION
When i tried to rewrite the k05885 with jtframe primitives somehow my AI ended up serializing drawing of tiles and sprites during a line.
That is of course wrong and the original implementation we had before wasn't doing that either.
This change put it back to normal random access, both the tile engine and the sprite engine access the rom data when they need.

This is being currently play tested to see if it solves the last 2 glitches of sprites.