### PR TITLE
fix(): Cabal button names, music speed.

### DIFF
--- a/cores/toki/cfg/mame2mra.toml
+++ b/cores/toki/cfg/mame2mra.toml
@@ -18,7 +18,7 @@ skip.bootlegs=true
 [buttons]
 names = [
     { machines=["toki","jujuba"], names="Shoot,Jump" },
-    { machine="cabal", names="Fire,Roll,Grenade" },
+    { machine="cabal", names="Fire,Grenade,Roll" },
 ]
 
 [header]

--- a/cores/toki/cfg/mem.yaml
+++ b/cores/toki/cfg/mem.yaml
@@ -8,7 +8,7 @@ params:
   - { name: ADPCM1_OFFSET,    value:  "(`ADPCM1_START-`JTFRAME_BA1_START)>>1" }
   - { name: ADPCM2_OFFSET,    value:  "(`ADPCM2_START-`JTFRAME_BA1_START)>>1" }
 clocks:
-  clk48:
+  clk:
     - freq: 3579545
       outputs:
         - cen_fm
@@ -23,8 +23,9 @@ clocks:
 audio:
   channels:
     - { name: fm,   data_width: 16, rsum: 10k }
-    - { name: pcm0, data_width: 14, rsum: 10k }
-    - { name: pcm1, data_width: 14, rsum: 40k }
+    - { name: pcm0, data_width: 12, rsum: 40k }
+    - { name: pcm1, data_width: 12, rsum: 20k }
+    - { name: oki,  data_width: 14, rsum: 10k }
 sdram:
   banks:
     - buses:

--- a/cores/toki/cfg/mem.yaml
+++ b/cores/toki/cfg/mem.yaml
@@ -8,7 +8,7 @@ params:
   - { name: ADPCM1_OFFSET,    value:  "(`ADPCM1_START-`JTFRAME_BA1_START)>>1" }
   - { name: ADPCM2_OFFSET,    value:  "(`ADPCM2_START-`JTFRAME_BA1_START)>>1" }
 clocks:
-  clk:
+  clk48:
     - freq: 3579545
       outputs:
         - cen_fm

--- a/cores/toki/cfg/mem.yaml
+++ b/cores/toki/cfg/mem.yaml
@@ -24,7 +24,7 @@ audio:
   channels:
     - { name: fm,   data_width: 16, rsum: 10k }
     - { name: pcm0, data_width: 14, rsum: 10k }
-    - { name: pcm1, data_width: 14, rsum: 20k }
+    - { name: pcm1, data_width: 14, rsum: 40k }
 sdram:
   banks:
     - buses:

--- a/cores/toki/cfg/mem.yaml
+++ b/cores/toki/cfg/mem.yaml
@@ -24,7 +24,7 @@ audio:
   channels:
     - { name: fm,   data_width: 16, rsum: 10k }
     - { name: pcm0, data_width: 14, rsum: 10k }
-    - { name: pcm1, data_width: 14, rsum: 10k }
+    - { name: pcm1, data_width: 14, rsum: 20k }
 sdram:
   banks:
     - buses:

--- a/cores/toki/hdl/jttoki_game.v
+++ b/cores/toki/hdl/jttoki_game.v
@@ -260,6 +260,7 @@ jttoki_sound u_sound(
     .fm                 ( fm                 ),
     .pcm0               ( pcm0               ),
     .pcm1               ( pcm1               ),
+    .oki                ( oki                ),
 
     .rom_addr           ( snd_addr           ),
     .rom_data           ( snd_data           ),
@@ -298,8 +299,9 @@ jttoki_sound u_sound(
 );
 `else
 assign fm                 = 16'd0;
-assign pcm0               = 14'd0;
-assign pcm1               = 14'd0;
+assign pcm0               = 12'd0;
+assign pcm1               = 12'd0;
+assign oki                = 14'd0;
 assign snd_addr           = 13'd0;
 assign snd_cs             = 1'b0;
 assign bank_rom_addr      = 16'd0;

--- a/cores/toki/hdl/jttoki_sound.v
+++ b/cores/toki/hdl/jttoki_sound.v
@@ -26,8 +26,9 @@ module jttoki_sound(
     input       [1:0] coin,
 
     output signed [15:0] fm,
-    output signed [13:0] pcm0,
-    output signed [13:0] pcm1,
+    output signed [11:0] pcm0,
+    output signed [11:0] pcm1,
+    output signed [13:0] oki,
 
     input       [7:0] rom_data,
     input             rom_ok,
@@ -386,7 +387,8 @@ jt51 u_jt51(
 assign cabal_fm_snd = (jt51_l >>> 1) + (jt51_r >>> 1);
 
 assign fm   = cabal ? cabal_fm_snd : opl_snd;
-assign pcm0 = cabal ? {cabal_adpcm0_snd, 2'd0} : oki_snd;
-assign pcm1 = cabal ? {cabal_adpcm1_snd, 2'd0} : 14'sd0;
+assign pcm0 = cabal ? cabal_adpcm0_snd : 12'sd0;
+assign pcm1 = cabal ? cabal_adpcm1_snd : 12'sd0;
+assign oki  = cabal ? 14'sd0 : oki_snd;
 
 endmodule

--- a/cores/toki/hdl/jttoki_sound.v
+++ b/cores/toki/hdl/jttoki_sound.v
@@ -255,6 +255,9 @@ always @(posedge clk) begin
         else if (oki6295_irq_n == 1'b0) //~m68k_sound_cs_4
             irq_rst18 <= 1'b1;
 
+        if (!irq_ack && (cabal ? jt51_irq_n : ym3812_irq_n) == 1'b1)
+            irq_rst10 <= 1'b0;
+
         if (irq_ack & irq_rst10)
             stop_irq_10 <= 1'b1;
         else if (irq_ack & irq_rst18)


### PR DESCRIPTION
- reorder button names
- name the clock of music clock48 so that the framework knows how to handle it
- try to give a bigger rsum to the second adcpm channel that hopefully is the one too loud

closes #1461 