### PR TITLE
feat(): Add log upload in case of compilation failure

### DIFF
--- a/.github/workflows/compile-custom.yaml
+++ b/.github/workflows/compile-custom.yaml
@@ -96,6 +96,19 @@ jobs:
 
           docker run -e BETAKEY=${{ secrets.BETAKEY }} --network host -v "$(pwd)":/jtcores "$docker_image" /jtcores/modules/jtframe/devops/xjtcore.sh "${{ matrix.core }}" "${{ matrix.target }}"
 
+      # On a failed compile, ship the build log for triage. jtframe/bin/jtcore
+      # writes it to log/<target>/<core>.log inside the container, which maps
+      # to ./log/<target>/<core>.log on the runner via the $(pwd) -> /jtcores
+      # bind mount.
+      - id: upload-log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: log-${{ matrix.target }}-${{ matrix.core }}
+          path: log
+          retention-days: 7
+          if-no-files-found: warn
+
       - id: upload
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
This change to the action will allow for log uploads in case compilation file.
In this case was useful to me to understand i miss 3 bram blocks to fit blockout in the pocket.

In general logs are a good thing to have.