### PR TITLE
fix(x1-010): WAV is a bit of cfg not of ch

### DIFF
--- a/modules/jtx1010/hdl/jtx1010.sv
+++ b/modules/jtx1010/hdl/jtx1010.sv
@@ -75,7 +75,7 @@ wire keyoff;
 
 
 always_comb begin
-    kon     = ch[WAV] ? cfg[KEYON] & ~keyoff: cfg[KEYON];
+    kon     = cfg[WAV] ? cfg[KEYON] & ~keyoff: cfg[KEYON];
     cfg_din ={cfg[7:1],kon};
     cfg_we  = up && st==5'o30;
 end


### PR DESCRIPTION
I have been looking at the audio for metafox and arbalester looping, and i didn't solve anything.
Reading around the cpp file for the set x1-010 and the small documentation given, it looks like to me  WAV and KEYON are part of the cfg reg bits and so i think i spotted a typo/bug in this part of verilog.