### PR TITLE
pocket lfbuf ctrl: cr_wen in RD/WR event should change accordingly

### DIFF
--- a/modules/jtframe/hdl/video/jtframe_lfbuf_ctrl.v
+++ b/modules/jtframe/hdl/video/jtframe_lfbuf_ctrl.v
@@ -264,7 +264,7 @@ always @( posedge clk ) begin
                 cr_advn         <= 0;
                 adq_en          <= 1;
                 cr_oen          <= 1;
-                cr_wen          <= 1;
+                cr_wen          <=~wring;
                 st              <= wring ? WRITEOUT : READIN;
                 wait1           <= 1; // give time to cr_wait to react
             end


### PR DESCRIPTION
This was broken in a499899daa25a4b00288271f2123639578407583. This PR regresses this line to fix #1454 