### PR TITLE
Fix Linter_cores action

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -23,4 +23,4 @@ jobs:
         # pwd will be: /home/runner/work/jtcores/jtcores
         docker run --network host -v `pwd`:/jtcores jotego/linter /jtcores/modules/jtframe/bin/lint-all.sh
         docker run --network host -v `pwd`:/jtcores jotego/linter /jtcores/modules/jtframe/bin/lint-mra.sh
-        docker run --network host -v `pwd`:/jtcores jotego/linter -lc "cd /jtcores && source setprj.sh && jtrefresh --all --jobs 4"
+        docker run --network host -v `pwd`:/jtcores jotego/linter /jtcores/modules/jtframe/bin/jtrefresh --all --jobs 4

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -23,4 +23,4 @@ jobs:
         # pwd will be: /home/runner/work/jtcores/jtcores
         docker run --network host -v `pwd`:/jtcores jotego/linter /jtcores/modules/jtframe/bin/lint-all.sh
         docker run --network host -v `pwd`:/jtcores jotego/linter /jtcores/modules/jtframe/bin/lint-mra.sh
-        docker run --network host -v `pwd`:/jtcores jotego/linter bash -lc "cd /jtcores && source setprj.sh && jtrefresh --all --jobs 4"
+        docker run --network host -v `pwd`:/jtcores jotego/linter -lc "cd /jtcores && source setprj.sh && jtrefresh --all --jobs 4"

--- a/modules/jtframe/bin/jtrefresh
+++ b/modules/jtframe/bin/jtrefresh
@@ -7,6 +7,8 @@
 # (at your option) any later version.
 
 main() {
+    setup_environment
+
     TARGET=sidi128
     FRAMES=3
     JOBS=1
@@ -25,6 +27,14 @@ main() {
     require_environment
     select_cores
     run_many
+}
+
+setup_environment() {
+    if [ -z "$JTFRAME" ]; then
+        cd /jtcores
+        git config --global --add safe.directory /jtcores
+        source setprj.sh
+    fi
 }
 
 show_help() {

--- a/modules/jtframe/bin/lint-mra.sh
+++ b/modules/jtframe/bin/lint-mra.sh
@@ -4,10 +4,19 @@ FAIL=false
 BROKEN=()
 
 main() {
+	setup_environment
 	test_mra_generation
 	print_summary
 	if $FAIL; then
 		exit 1
+	fi
+}
+
+setup_environment() {
+	if [ -z "$JTFRAME" ]; then
+		cd /jtcores
+		git config --global --add safe.directory /jtcores
+		source setprj.sh
 	fi
 }
 


### PR DESCRIPTION
Linter_cores action was failing since 3912899d27ad86ced931355f2367f213af3cd4d1

Added self initialization for `lint-mra.sh` and `jtrefresh` to simplify `linter.yaml`. 

Not being initialized could have caused `lint-mra.sh` not actually running, since it uses `$CORES` but in case this is undefined, it could give a false `PASS`