### PR TITLE
fix(): Rastan sound error in service mode

### DIFF
--- a/cores/rastan/hdl/jtrastan_main.v
+++ b/cores/rastan/hdl/jtrastan_main.v
@@ -235,7 +235,7 @@ always @(posedge clk, posedge rst) begin
     end
 end
 
-jtframe_68kdtack_cen #(.W(8)) u_dtack(
+jtframe_68kdtack_cen #(.W(12)) u_dtack(
     .rst        ( rst       ),
     .clk        ( clk       ),
     .cpu_cen    ( cpu_cen   ),
@@ -246,8 +246,11 @@ jtframe_68kdtack_cen #(.W(8)) u_dtack(
     .bus_ack    ( 1'b0      ),
     .ASn        ( ASn       ),
     .DSn        ({UDSn,LDSn}),
-    .num        ( 7'd1      ),  // numerator
-    .den        ( 8'd6      ),  // denominator
+    // Same divider chain as the Z80: on the board both CPUs come off the one
+    // 16MHz XTAL, exactly 2:1.
+    // This runs on clk48 and the z80 runs on clk24
+    .num        ( 11'd231   ),
+    .den        ( 12'd1541  ),
     .DTACKn     ( DTACKn    ),
     .wait2      ( 1'b0      ),
     .wait3      ( 1'b0      ),


### PR DESCRIPTION
This is tied to the issue #1215 investigation.

On the original board schematics the cpu 68000 and z80 are on the same clock chain in ratio 2:1 from a generator of 16Mhz we get 8 and 4 Mhz, on the same signal.

Here they were taken with different dividers chain making the 68000 8800Mhz  and out of phase with the z80 4Mhz.

This clears the sound error in simulation,  i ll make an hardware build to see how it behaves, it may not change the sword sound, that could be one of many things including just audio filtering.