### PR TITLE
fix(rastan): Video align for operation wolf and rastand and timing fix 

### DIFF
--- a/cores/rastan/hdl/jtrastan_obj.v
+++ b/cores/rastan/hdl/jtrastan_obj.v
@@ -139,7 +139,7 @@ always @(posedge clk, posedge rst) begin
             rom_addr <= { code[12:0], ydiff[3:0]^{4{~attr[15]}}, attr[14] };
             half     <= 0;
             dr_busy  <= 1;
-            buf_pos  <= xpos[8:0] + 9'd14;
+            buf_pos  <= xpos[8:0] + 9'd13;
             cur_pal  <= attr[3:0];
             cur_hflip<= attr[14];
             buf_we   <= 0;

--- a/cores/rastan/hdl/jtrastan_scr.v
+++ b/cores/rastan/hdl/jtrastan_scr.v
@@ -70,19 +70,16 @@ module jtrastan_scr(
     output   [ 7:0] debug_view
 );
 
-wire [ 8:0] vdump;
+wire [ 8:0] vdump, vrender_raw;
 reg  [15:0] scr0_hpos, scr1_hpos, scr0_vpos, scr1_vpos;
+
+localparam [8:0] VADJ = 9'd1;
+wire [ 8:0] vdump_adj = vdump + VADJ;
 
 assign dtackn = 0;
 assign debug_view = scr1_hpos[8:1];
-/*
-reg LVBLl;
+assign vrender    = vrender_raw + VADJ; // sprites (obj) sample by vrender
 
-always @(posedge clk) begin
-    LVBLl <= LVBL;
-    if( ~LVBL && LVBLl ) scr0_hpos <= scr0_hpos + 1'd1;
-end
-*/
 always @(posedge clk, posedge rst) begin
     if( rst ) begin
         scr0_hpos <= 0;
@@ -116,15 +113,15 @@ jtframe_vtimer #(
     .VB_START   ( 9'd239          ),
     .VB_END     ( 9'd239+9'd23    ),
     .VS_START   ( 9'd239+9'd7     ),
-    .HB_END     ( 9'hF            ),
-    .HB_START   ( 9'h14F          ),
+    .HB_END     ( 9'hA            ),
+    .HB_START   ( 9'h14A          ),
     .HCNT_END   ( 9'd319+9'd104   ),
     .HS_START   ( 9'd320+9'd44    )
 ) u_vtimer(
     .clk        ( clk       ),
     .pxl_cen    ( pxl_cen   ),
     .vdump      ( vdump     ),
-    .vrender    ( vrender   ),
+    .vrender    ( vrender_raw ),
     .vrender1   (           ),
     .H          ( hdump     ),
     .Hinit      (           ),
@@ -141,7 +138,7 @@ jtrastan_tilemap u_scr0( // background
 
     .flip       ( flip      ),
     .hdump      ( hdump     ),
-    .vdump      ( vdump     ),
+    .vdump      ( vdump_adj ),
 
     .hpos       ( scr0_hpos[8:0] ),
     .vpos       ( scr0_vpos[8:0] ),
@@ -166,7 +163,7 @@ jtrastan_tilemap #(1) u_scr1( // foreground
 
     .flip       ( flip      ),
     .hdump      ( hdump     ),
-    .vdump      ( vdump     ),
+    .vdump      ( vdump_adj ),
 
     .hpos       ( scr1_hpos[8:0] ),
     .vpos       ( scr1_vpos[8:0] ),

--- a/cores/rastan/hdl/jtrastan_snd.v
+++ b/cores/rastan/hdl/jtrastan_snd.v
@@ -66,6 +66,7 @@ wire        [ 3:0] pcm0_nibble, pcm1_nibble;
 wire signed [11:0] pcm0_raw, pcm1_raw;
 wire signed [20:0] pcm0_scaled, pcm1_scaled;
 wire signed [11:0] pcm0_atten, pcm1_atten;
+reg  signed [11:0] pcm0_q,     pcm1_q;
 reg         [15:0] pcm0_start, pcm0_end, pcm1_start, pcm1_end;
 reg         [ 7:0] pcm0_vol, pcm1_vol;
 reg         [ 7:0] din;
@@ -78,10 +79,14 @@ assign pcm0_scaled = pcm0_raw * $signed({1'b0,pcm0_vol});
 assign pcm1_scaled = pcm1_raw * $signed({1'b0,pcm1_vol});
 assign pcm0_atten = pcm0_scaled[19:8];
 assign pcm1_atten = pcm1_scaled[19:8];
-assign pcm0 = opwolf ? pcm0_atten : pcm0_raw;
-assign pcm1 = pcm1_atten;
+assign pcm0 = pcm0_q;
+assign pcm1 = pcm1_q;
 
+// Register the volume-scaled PCM before the RC mixer to break a long combiational path
+// that miss the timings on pocket at 53Mhz
 always @(posedge clk) begin
+    pcm0_q   <= opwolf ? pcm0_atten : pcm0_raw;
+    pcm1_q   <= pcm1_atten;
     snd_rstn <= ~(rst | pc6_rst);
 end
 


### PR DESCRIPTION
This PR aims at fixing 2 issues with the current rastan/opwolf core.
1) timings on pocket broke in master with the addition of opwolf
2) opwolf makes clear that the video is shifted. If compared with mame both rastan and opwolf are shifted 5px on the left and 1 px down compared to the emulator.

While rastan is not noticeable the difference, opwolf is clearly broken.

Before

<img width="320" height="774" alt="opwolf_stack" src="https://github.com/user-attachments/assets/48b7f9ae-e6aa-47b6-b89d-93ce806048d9" />

<img width="320" height="774" alt="rastan_stack" src="https://github.com/user-attachments/assets/cf1bf802-f45c-4858-a480-72a3ed4040fb" />

After

<img width="320" height="774" alt="opwolfp_2804_hostage_stack" src="https://github.com/user-attachments/assets/502e42fb-ec24-41a1-a0d7-18ccb7d76dea" />
<img width="320" height="774" alt="opwolfp_4200_map_stack" src="https://github.com/user-attachments/assets/5d2e1bb6-fa86-4f60-9520-3d0923316a61" />
<img width="680" height="546" alt="rastan_before_after" src="https://github.com/user-attachments/assets/a257450c-2b1b-430b-9704-6c2578e40688" />


The solution for the timing seems to be to break down the audio with a reg, producing a 1 clock shift in audio that shouldn't be an issue.
