### PR TITLE
fix(): tc0030 fix for the aN port.

### DIFF
--- a/modules/jttc0030cmd/hdl/IKA87AD.sv
+++ b/modules/jttc0030cmd/hdl/IKA87AD.sv
@@ -2480,6 +2480,11 @@ logic   [4:0]   current_adc_mode;
 logic   [7:0]   adc_state_cntr;
 logic   [2:0]   adc_ch;
 logic           adc_strobe_n;
+logic           anm_wr_pend;
+
+//manual 8.2: writing ANM stops the conversion in progress and restarts from
+//the beginning of the newly selected mode/group, storing into CR0
+wire anm_wr = cycle_tick & reg_SRTMP_wr & (spr_rw_addr == 6'h08);
 
 assign o_ANx_ANALOG_CH = current_adc_mode[0] ? current_adc_mode[3:1] : adc_ch;
 assign o_ANx_ANALOG_RD_n = adc_strobe_n;
@@ -2491,9 +2496,16 @@ always_ff @(posedge emuclk) begin
         current_adc_mode <= 5'b00000;
         adc_state_cntr <= 8'd0;
         adc_ch <= 3'd0;
+        anm_wr_pend <= 1'b0;
     end
     else begin if(div3_tick) begin
-        if(( current_adc_mode[4] && adc_state_cntr == 8'd143) || 
+        if(anm_wr_pend) begin
+            anm_wr_pend <= 1'b0;
+            current_adc_mode <= spr_ANM;
+            adc_ch <= {spr_ANM[3], 2'b00};
+            adc_state_cntr <= 8'd0;
+        end
+        else if(( current_adc_mode[4] && adc_state_cntr == 8'd143) ||
            (~current_adc_mode[4] && adc_state_cntr == 8'd191)) begin
 
             //make a copy of the current ANM reg value
@@ -2520,7 +2532,9 @@ always_ff @(posedge emuclk) begin
             adc_strobe_n <= current_adc_mode[4] ? 1'b0 : 1'b1;
             if(~current_adc_mode[4]) spr_CR[adc_ch[1:0]] <= i_ANx_ANALOG_DATA;
         end
-    end end
+    end
+    if(anm_wr) anm_wr_pend <= 1'b1;
+    end
 end
 
 

--- a/modules/jttc0030cmd/ver/adcscan/adcscan_mrom.hex
+++ b/modules/jttc0030cmd/ver/adcscan/adcscan_mrom.hex
@@ -1,0 +1,57 @@
+// Custom uPD78C11 firmware for the jttc0030cmd ADC scan-group unit test.
+// ORIGINAL code, not derived from any game's C-chip mask ROM.
+//
+// Reproduces the pattern Taito's C-chip firmware uses to read all eight AN
+// pins as digital inputs: it alternates ANM between scan/AN0-AN3 (00) and
+// scan/AN4-AN7 (08) without ever changing the mode bit. Per uPD78C1x manual
+// 8.2, every ANM write must abort the running conversion and restart from
+// the newly selected group's first channel into CR0. After each group has had
+// time to complete, the four CR registers are copied to shared RAM so the
+// host can check them:
+//     word 0..3 = CR0..CR3 after the AN0-AN3 scan
+//     word 4..7 = CR0..CR3 after the AN4-AN7 scan
+//     word 8    = pass marker, toggles 00/FF each loop
+// $readmemh ignores // comments; each token is one program byte.
+//
+//   addr  bytes       mnemonic
+6B 00      //  0000  MVI  C,#$00       ; pass marker register, once
+69 00      //  0002  MVI  A,#$00       ; <-- loop entry
+4D C8      //  0004  MOV  ANM,A        ; scan mode, AN0-AN3
+6A FF      //  0006  MVI  B,#$FF       ; \
+52         //  0008  DCR  B            ;  } delay > 4 conversions
+54 08 00   //  0009  JMP  $0008        ; back to DCR (skipped when B hits 0)
+4C E0      //  000C  MOV  A,CR0
+34 00 10   //  000E  LXI  H,#$1000
+3B         //  0011  STAX H            ; word0 = CR0
+4C E1      //  0012  MOV  A,CR1
+34 01 10   //  0014  LXI  H,#$1001
+3B         //  0017  STAX H            ; word1 = CR1
+4C E2      //  0018  MOV  A,CR2
+34 02 10   //  001A  LXI  H,#$1002
+3B         //  001D  STAX H            ; word2 = CR2
+4C E3      //  001E  MOV  A,CR3
+34 03 10   //  0020  LXI  H,#$1003
+3B         //  0023  STAX H            ; word3 = CR3
+69 08      //  0024  MVI  A,#$08
+4D C8      //  0026  MOV  ANM,A        ; scan mode, AN4-AN7 (mode bit unchanged)
+6A FF      //  0028  MVI  B,#$FF
+52         //  002A  DCR  B
+54 2A 00   //  002B  JMP  $002A        ; back to DCR (skipped when B hits 0)
+4C E0      //  002E  MOV  A,CR0
+34 04 10   //  0030  LXI  H,#$1004
+3B         //  0033  STAX H            ; word4 = CR0
+4C E1      //  0034  MOV  A,CR1
+34 05 10   //  0036  LXI  H,#$1005
+3B         //  0039  STAX H            ; word5 = CR1
+4C E2      //  003A  MOV  A,CR2
+34 06 10   //  003C  LXI  H,#$1006
+3B         //  003F  STAX H            ; word6 = CR2
+4C E3      //  0040  MOV  A,CR3
+34 07 10   //  0042  LXI  H,#$1007
+3B         //  0045  STAX H            ; word7 = CR3
+34 08 10   //  0046  LXI  H,#$1008
+0B         //  0049  MOV  A,C          ; C = pass marker, kept in a register
+74 11 FF   //  004A  XRI  A,#$FF       ; toggle 00<->FF
+1B         //  004D  MOV  C,A
+3B         //  004E  STAX H            ; word8 = marker
+54 02 00   //  004F  JMP  $0002        ; loop

--- a/modules/jttc0030cmd/ver/adcscan/gather.f
+++ b/modules/jttc0030cmd/ver/adcscan/gather.f
@@ -1,0 +1,8 @@
+../../hdl/jttc0030cmd.v
+../../hdl/IKA87AD_mnemonics.sv
+../../hdl/IKA87AD_primitives.sv
+../../hdl/IKA87AD_opdec.sv
+../../hdl/IKA87AD_microcode.sv
+../../hdl/IKA87AD.sv
+../../../jtframe/hdl/ram/jtframe_prom.v
+../../../jtframe/hdl/ram/jtframe_dual_ram.v

--- a/modules/jttc0030cmd/ver/adcscan/test.v
+++ b/modules/jttc0030cmd/ver/adcscan/test.v
@@ -1,0 +1,146 @@
+// Unit test: uPD78C11 ADC scan-group switching in jttc0030cmd.
+//
+// Taito's C-chip firmware reads all eight AN pins as digital inputs by
+// alternating ANM between scan/AN0-AN3 and scan/AN4-AN7 with the mode bit
+// held constant. uPD78C1x manual 8.2: writing ANM stops the running conversion
+// and restarts from the newly selected group into CR0. Before the fix the
+// group counter only re-initialised on a mode-bit change, so AN4-AN7 were
+// never sampled and their CR results were stale group-0 data (Volfied's P2
+// left/right/button on AN7/AN4/AN5 stayed dead while up/down on AN1/AN2
+// worked).
+//
+// `adcscan_mrom.hex` (custom firmware, see the file) copies CR0..CR3 to
+// shared-RAM words 0..3 after the AN0-AN3 scan and to words 4..7 after the
+// AN4-AN7 scan. Each AN pin is driven with a distinct level so every CR
+// result identifies exactly which channel was converted: the wrapper returns
+// 0xFF for an[ch]=1 and 0x00 for an[ch]=0, matching taitocchip.cpp.
+`timescale 1ns/1ps
+module test;
+    reg        clk = 0, rst = 1;
+    reg  [2:0] cdiv = 0;
+    wire       cen  = (cdiv == 3'd5);        // /6 MCU clock enable
+    always #10 clk = ~clk;
+    always @(posedge clk) cdiv <= cen ? 3'd0 : cdiv + 3'd1;
+
+    reg         cs = 0, rnw = 1;
+    reg  [10:0] addr = 0;
+    reg  [ 7:0] din = 0;
+    wire [ 7:0] dout;
+    wire        dtack_n;
+    reg  [ 7:0] an = 8'h00;
+
+    wire [11:0] mrom_addr;
+    wire [12:0] eprom_addr;
+    wire [ 7:0] mrom_data;
+
+    jttc0030cmd uut(
+        .rst(rst), .clk(clk), .cen(cen),
+        .cs(cs), .addr(addr), .din(din), .dout(dout), .rnw(rnw), .dtack_n(dtack_n),
+        .int1(1'b0), .nmi_n(1'b1),
+        .pa_in(8'd0), .pb_in(8'd0), .pc_in(8'd0),
+        .pa_out(), .pb_out(), .pc_out(),
+        .an(an),
+        .mrom_addr(mrom_addr), .mrom_data(mrom_data),
+        .eprom_addr(eprom_addr), .eprom_data(8'd0),
+        .dbg_pc(), .dbg_fetch()
+    );
+
+    jtframe_prom #(.DW(8),.AW(12),.SIMHEX("adcscan_mrom.hex")) u_mask(
+        .clk(clk), .cen(1'b1), .data(8'd0),
+        .rd_addr(mrom_addr), .wr_addr(12'd0), .we(1'b0), .q(mrom_data)
+    );
+
+    integer errors = 0;
+    reg [7:0] q, mark;
+    integer i, timeout;
+
+    task host_read(input [10:0] a, output [7:0] d);
+        begin
+            @(posedge clk); cs = 1; rnw = 1; addr = a;
+            repeat (3) @(posedge clk);
+            d = dout;
+            cs = 0;
+            @(posedge clk);
+        end
+    endtask
+
+    task expect_eq(input [7:0] got, input [7:0] exp, input [127:0] name);
+        begin
+            if (got !== exp) begin
+                $display("FAIL: %0s = %02x, expected %02x", name, got, exp);
+                errors = errors + 1;
+            end else begin
+                $display("ok: %0s = %02x", name, got);
+            end
+        end
+    endtask
+
+    // The firmware toggles shared-RAM word 8 (00<->FF) at the end of every
+    // loop, after all eight CR copies. Wait for it to change N times, so N
+    // complete iterations have run against the current `an`.
+    task wait_loops(input integer n);
+        integer k;
+        begin
+            for (k = 0; k < n; k = k + 1) begin
+                host_read(11'h008, mark);
+                timeout = 0;
+                host_read(11'h008, q);
+                while (q == mark && timeout < 4000) begin
+                    repeat (200) @(posedge clk);
+                    host_read(11'h008, q);
+                    timeout = timeout + 1;
+                end
+                if (q == mark) begin
+                    $display("FAIL: firmware loop marker stuck at %02x", mark);
+                    errors = errors + 1;
+                end
+            end
+        end
+    endtask
+
+    // Check one full loop's worth of results against the current `an` pattern.
+    // words 0..3 <- AN0..AN3, words 4..7 <- AN4..AN7
+    task check_all(input [127:0] label);
+        reg [7:0] exp;
+        begin
+            for (i = 0; i < 8; i = i + 1) begin
+                exp = an[i] ? 8'hFF : 8'h00;
+                host_read(i[10:0], q);
+                expect_eq(q, exp, {label, " AN", "0"+i[7:0]});
+            end
+        end
+    endtask
+
+    initial begin
+        repeat (20) @(posedge clk);
+        rst = 0;
+        // bank_68k = 0 (host window on shared-RAM bank 0)
+        @(posedge clk); cs = 1; rnw = 0; addr = 11'h600; din = 8'h00;
+        @(posedge clk); cs = 0; rnw = 1;
+
+        // ---- pattern 1: only the upper group has a set bit per channel ----
+        // AN7..AN0 = 1010_0110  -> upper: AN7=1 AN6=0 AN5=1 AN4=0
+        //                          lower: AN3=0 AN2=1 AN1=1 AN0=0
+        an = 8'b1010_0110;
+        // two full loops so both groups reflect `an`
+        wait_loops(2);
+        check_all("p1");
+
+        // ---- pattern 2: the Volfied case, all pins idle-high but one ----
+        // P2 LEFT is AN7 low with everything else high: idle port = FF,
+        // pressed = 7F. Before the fix AN7 was never sampled.
+        an = 8'b0111_1111;
+        wait_loops(2);
+        check_all("p2");
+
+        // ---- pattern 3: lower group all clear, upper group all set ----
+        // Distinguishes a real AN4-AN7 scan from stale AN0-AN3 data outright.
+        an = 8'b1111_0000;
+        wait_loops(2);
+        check_all("p3");
+
+        if (errors == 0) $display("PASS");
+        else             $display("FAIL: %0d error(s)", errors);
+        $finish;
+    end
+endmodule


### PR DESCRIPTION
Volfied fails at reading some the inputs through the `an` port.
I asked Raki about it, i showed him the part that was likely the culprit and he gave me the manual section to digest.

The an port has 8 bits that get read in group continuosly, 0 to 3 and 4 to 7.

<img width="890" height="740" alt="image" src="https://github.com/user-attachments/assets/14957a63-a731-4eea-ba3a-46af1c1c9d0b" />

the choice of the group is made with ANI2.

Now current code changes of ANI2 only when ANI0 changes. When ANI0 does not change  the loop is:
```v
 //scan mode/single ch mode select
if(spr_ANM[0] != current_adc_mode[0]) adc_ch <= {spr_ANM[3], 2'b00}; //if the mode has been changed, initialize the counter
else adc_ch[1:0] <= adc_ch[1:0] == 2'b11 ? 2'b00 : adc_ch[1:0] + 2'b01; //count up
```
a continue loop between 0 and 3, skipping 4-7 where volfied player 2 controls ( left/right/button1) are.

Volfied firmware switches the group bit without touching the bit 0, so the current code always ignore it.

```asm
202a: MVI ANM,$06    ; 00110 -> MS=0 scan, ANI2=0  => AN0-AN3
2031-2052: CR0..CR3 -> result bits 0,1,2,3
205d: MVI ANM,$0E    ; 01110 -> MS=0 scan, ANI2=1  => AN4-AN7
2064-2085: CR0..CR3 -> result bits 4,5,6,7
2090: MOV A,B        ; return assembled 8-bit port
```

Now there is a section to the manual that says ( page140 ):

<img width="1024" height="212" alt="image" src="https://github.com/user-attachments/assets/fe91629c-ed9c-4f4b-84df-40b207988acc" />

This means that our line of c-chip firmware 205d, after the 202a needs to block the current reading, reset everything to initial values, read again the ANI2 bit and change upper/lower group of scanning.

This PR introduce a 'write pending' reg that if set to 1 will exactly re-init the reading.

This PR is for review, volfied needs to be built from this branch and the issue verified as closed outside of the unit test provided.

The unit test mimic volfied behavior with a custom firmware for the c-chip.
