### PR TITLE
Gradius III Scoreboard Fix

### DIFF
--- a/modules/jtframe/hdl/video/jtframe_draw.v
+++ b/modules/jtframe/hdl/video/jtframe_draw.v
@@ -97,9 +97,6 @@ always @(posedge clk) begin
                 cnt     <= 8;
                 no_zoom <= hzoom == HZONE || hzoom == 0; // zoom=0 is not valid. Makes counts keep going and busy stays forever. Check simpsons/scene 32
                 if( !hz_keep ) begin
-                    // enlarging needs hz_cnt=hzoom for exact integer factors,
-                    // shrinking needs a full step or the first borrow always
-                    // lands on the second pixel and drops a column of the sprite
                     hz_cnt   <= ZENLARGE==1 ? hzoom : {ZW{1'b1}};
                     buf_addr <= xpos;
                 end

--- a/modules/jtframe/hdl/video/jtframe_draw.v
+++ b/modules/jtframe/hdl/video/jtframe_draw.v
@@ -97,7 +97,10 @@ always @(posedge clk) begin
                 cnt     <= 8;
                 no_zoom <= hzoom == HZONE || hzoom == 0; // zoom=0 is not valid. Makes counts keep going and busy stays forever. Check simpsons/scene 32
                 if( !hz_keep ) begin
-                    hz_cnt   <= hzoom;
+                    // enlarging needs hz_cnt=hzoom for exact integer factors,
+                    // shrinking needs a full step or the first borrow always
+                    // lands on the second pixel and drops a column of the sprite
+                    hz_cnt   <= ZENLARGE==1 ? hzoom : {ZW{1'b1}};
                     buf_addr <= xpos;
                 end
             end


### PR DESCRIPTION
Before:
<img width="1024" height="768" alt="before" src="https://github.com/user-attachments/assets/7f736941-9dd8-4261-a695-351f44c56888" />
After: 
<img width="1280" height="896" alt="after" src="https://github.com/user-attachments/assets/0ec0a997-f6d3-440c-bdbe-70135d1710ed" />
