### PR TITLE
Gradius III Phantom Death Fix

### DIFF
--- a/cores/grad3/cfg/files.yaml
+++ b/cores/grad3/cfg/files.yaml
@@ -4,6 +4,7 @@ grad3:
     - jtgrad3_main.v
     - jtgrad3_sub.v
     - jtgrad3_video.v
+    - jtgrad3_arbiter.v
     - jtgrad3_colmix.v
     - jtgrad3_sound.v
 aliens:

--- a/cores/grad3/hdl/jtgrad3_arbiter.v
+++ b/cores/grad3/hdl/jtgrad3_arbiter.v
@@ -1,0 +1,35 @@
+/* SPDX-FileCopyrightText: 2026 Chris Watson
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * Date: 24-8-2026 */
+
+// F22, the video bus mutex: one 74LS74 with its halves clocked on opposite
+// phases of the 24 MHz clock, each Q asynchronously presetting the other.
+// Active low: req_n=0 requests, grant_n=0 is granted. Idle grants nobody.
+// The a side is clocked on the earlier phase, so it wins under sustained
+// contention.
+
+module jtgrad3_arbiter(
+    input       rst,
+    input       clk,
+    input       cen24,
+    input       a_req_n,
+    input       b_req_n,
+    output reg  a_grant_n,
+    output reg  b_grant_n
+);
+
+reg cen24b;
+
+always @(posedge clk) cen24b <= cen24;
+
+always @(posedge clk) begin
+    if( rst ) begin
+        a_grant_n <= 1;
+        b_grant_n <= 1;
+    end else begin
+        if( !b_grant_n ) a_grant_n <= 1; else if( cen24  ) a_grant_n <= a_req_n;
+        if( !a_grant_n ) b_grant_n <= 1; else if( cen24b ) b_grant_n <= b_req_n;
+    end
+end
+
+endmodule

--- a/cores/grad3/hdl/jtgrad3_game.v
+++ b/cores/grad3/hdl/jtgrad3_game.v
@@ -16,6 +16,7 @@ wire        m_tile_cs,  s_tile_cs, s_obj_cs,  pal_cs;
 wire        m_tile_dtack, s_tile_dtack;
 wire        tile_irqn, tile_nmin, sub_irq2;
 wire        rmrd, prio;
+wire        m_video_req_n, s_video_req_n, m_video_gnt_n, s_video_gnt_n;
 
 assign debug_view = st_snd;
 assign dip_flip   = 1'b0;
@@ -48,6 +49,8 @@ jtgrad3_main u_main(
     .tile_cs    ( m_tile_cs    ),
     .tile_dout  ( tile_dout    ),
     .tile_dtack ( m_tile_dtack ),
+    .video_req_n( m_video_req_n),
+    .video_grant_n(m_video_gnt_n),
 
     .gchar_cs   ( m_gchar_cs   ),
     .gchar_we   ( m_gchar_we   ),
@@ -100,6 +103,8 @@ jtgrad3_sub u_sub(
     .tile_cs    ( s_tile_cs    ),
     .tile_dout  ( tile_dout    ),
     .tile_dtack ( s_tile_dtack ),
+    .video_req_n( s_video_req_n),
+    .video_grant_n(s_video_gnt_n),
 
     .obj_cs     ( s_obj_cs     ),
     .obj_dout   ( obj_dout     ),
@@ -124,6 +129,7 @@ jtgrad3_video u_video(
     .clk          ( clk             ),
     .pxl_cen      ( pxl_cen         ),
     .pxl2_cen     ( pxl2_cen        ),
+    .cen24        ( cen24           ),
     .prio         ( prio            ),
 
     .lhbl         ( LHBL            ),
@@ -143,6 +149,10 @@ jtgrad3_video u_video(
     .s_cpu_dout   ( s_dout          ),
     .s_cpu_we     ( s_cpu_we        ),
     .m_tilesys_cs ( m_tile_cs       ),
+    .m_video_req_n( m_video_req_n   ),
+    .s_video_req_n( s_video_req_n   ),
+    .m_video_grant_n(m_video_gnt_n  ),
+    .s_video_grant_n(s_video_gnt_n  ),
     .s_tilesys_cs ( s_tile_cs       ),
     .objsys_cs    ( s_obj_cs        ),
     .m_vdtack     ( m_tile_dtack    ),

--- a/cores/grad3/hdl/jtgrad3_main.v
+++ b/cores/grad3/hdl/jtgrad3_main.v
@@ -27,6 +27,8 @@ module jtgrad3_main(
     output reg           tile_cs,
     input         [ 7:0] tile_dout,
     input                tile_dtack,
+    output               video_req_n,
+    input                video_grant_n,
 
     output reg           gchar_cs,
     output               gchar_we,
@@ -64,6 +66,8 @@ wire        cab_cs, BUSn;
 reg         snd_latch_cs, snd_irq_cs, wdog_cs, sub_irq_cs,
             ctrl_cs, io_cs, dsw_cs, dec_cs;
 wire        bus_cs, bus_busy, vdtackn, vbl_irqn, lvbln, vbl_clr, irq_en;
+reg         gchar_sel;
+wire        video_req;
 wire [ 7:0] ctrl;
 reg  [15:0] cpu_din;
 reg  [ 7:0] cab_dout;
@@ -90,13 +94,16 @@ assign cpu_we     = ~RnW;
 assign snd_irq    = |snd_cnt;
 
 assign cab_cs   = io_cs  | dsw_cs;
-assign bus_cs   = rom_cs | ram_cs | pal_cs | tile_cs | gchar_cs | sh_cs |
+assign bus_cs   = rom_cs | ram_cs | pal_cs | tile_cs | gchar_sel | sh_cs |
                   ctrl_cs | io_cs | dsw_cs | snd_latch_cs | snd_irq_cs | wdog_cs;
 wire [1:0] ok_cs, ok_in;
 assign ok_cs = { rom_cs, gchar_cs };
 assign ok_in = { rom_ok, gchar_ok };
+assign video_req = (tile_cs | gchar_sel) & ~BUSn;
+assign video_req_n = ~video_req;
 assign bus_busy = (rom_cs   & ~ok_dly)   |
                   (gchar_cs & ~ok_dly)   |
+                  (video_req & video_grant_n) |
                   (tile_cs  & ~tile_dtack);
 assign vdtackn  = DTACKn | (tile_cs & ~tile_dtack);
 assign VPAn     = ~( A[23] & ~ASn );
@@ -119,6 +126,7 @@ always @* begin
     sh_cs        = 0;
     tile_cs      = 0;
     gchar_cs     = 0;
+    gchar_sel    = 0;
     ctrl_cs      = 0;
     io_cs        = 0;
     dsw_cs       = 0;
@@ -139,7 +147,7 @@ always @* begin
             3'd3: io_dec_cs = 1;
             3'd4: sh_cs     = 1;
             3'd5: tile_cs   = 1;
-            3'd6: gchar_cs  = !BUSn;
+            3'd6: begin gchar_sel = !BUSn; gchar_cs = !BUSn & ~video_grant_n; end
             default:;
         endcase
     end

--- a/cores/grad3/hdl/jtgrad3_sub.v
+++ b/cores/grad3/hdl/jtgrad3_sub.v
@@ -30,6 +30,8 @@ module jtgrad3_sub(
     output reg           tile_cs,
     input         [ 7:0] tile_dout,
     input                tile_dtack,
+    output               video_req_n,
+    input                video_grant_n,
 
     output reg           obj_cs,
     input         [ 7:0] obj_dout,
@@ -60,6 +62,8 @@ wire        irq1_clr, irq2_clr, irq4_clr, BUSn;
 reg  [15:0] cpu_din;
 wire        ok_dly;
 reg         irqmask_cs, ram_cs, prog_dec_cs, vid_dec_cs, sh_cs;
+reg         gchar_sel;
+wire        video_req;
 reg  [ 2:0] irq_mask;
 
 assign rst_cpu   = rst | sub_rst;
@@ -77,13 +81,16 @@ assign sh_we     = dws & {2{sh_cs}};
 assign gchar_we  = ~RnW;
 assign cpu_we    = ~RnW;
 
-assign bus_cs    = rom_cs | ram_cs | tile_cs | obj_cs | gchar_cs | gfx_cs | sh_cs | irqmask_cs;
+assign bus_cs    = rom_cs | ram_cs | tile_cs | obj_cs | gchar_sel | gfx_cs | sh_cs | irqmask_cs;
 wire [2:0] ok_cs, ok_in;
 assign ok_cs = { rom_cs, gchar_cs, gfx_cs };
 assign ok_in = { rom_ok, gchar_ok, gfx_ok };
+assign video_req = (tile_cs | gchar_sel) & ~BUSn;
+assign video_req_n = ~video_req;
 assign bus_busy  = (rom_cs   & ~ok_dly)   |
                    (gchar_cs & ~ok_dly)   |
                    (gfx_cs   & ~ok_dly)   |
+                   (video_req & video_grant_n) |
                    (tile_cs  & ~tile_dtack);
 assign vdtackn   = DTACKn | (tile_cs & ~tile_dtack);
 assign VPAn      = ~( A[23] & ~ASn );
@@ -97,6 +104,7 @@ always @* begin
     tile_cs     = 0;
     obj_cs      = 0;
     gchar_cs    = 0;
+    gchar_sel   = 0;
     gfx_cs      = 0;
     sh_cs       = 0;
     irqmask_cs  = 0;
@@ -123,7 +131,7 @@ always @* begin
         case( A[19:18] )
             2'd0: sh_cs    = 1;
             2'd1: tile_cs  = 1;
-            2'd2: gchar_cs = !BUSn;
+            2'd2: begin gchar_sel = !BUSn; gchar_cs = !BUSn & ~video_grant_n; end
             2'd3: obj_cs   = 1;
             default:;
         endcase

--- a/cores/grad3/hdl/jtgrad3_video.v
+++ b/cores/grad3/hdl/jtgrad3_video.v
@@ -9,6 +9,7 @@ module jtgrad3_video(
     input             clk,
     input             pxl_cen,
     input             pxl2_cen,
+    input             cen24,
     input             prio,
 
     output            lhbl,
@@ -29,6 +30,10 @@ module jtgrad3_video(
     input             s_cpu_we,
     input             m_tilesys_cs,
     input             s_tilesys_cs,
+    input             m_video_req_n,
+    input             s_video_req_n,
+    output            m_video_grant_n,
+    output            s_video_grant_n,
     input             objsys_cs,
     output            m_vdtack,
     output            s_vdtack,
@@ -86,21 +91,24 @@ wire        rst8, e, q, ormrd, obj_irqn, obj_nmin, shadow;
 wire        lyrf_blnk_n, lyra_blnk_n, lyrb_blnk_n, lyro_blnk_n;
 wire        cpu_weg, obj_cpu_weg, tilesys_cs, vdtack;
 wire        m_tile_req, s_tile_req, m_tile_grant, s_tile_grant;
+wire        m_tile_gnt_n, s_tile_gnt_n;
 wire [ 1:0] tile_cpu_dsn;
 wire [15:0] tile_cpu_dout;
 wire        tile_cpu_we;
 reg  [13:0] ocode_eff;
 reg  [ 7:0] opal_eff;
 
-assign m_tile_req    = m_tilesys_cs && m_cpu_dsn != 2'b11;
-assign s_tile_req    = s_tilesys_cs && s_cpu_dsn != 2'b11;
-assign s_tile_grant  = s_tile_req;
-assign m_tile_grant  = m_tile_req && !s_tile_req;
+assign m_tile_req    = ~m_video_req_n;
+assign s_tile_req    = ~s_video_req_n;
+assign m_video_grant_n = m_tile_gnt_n;
+assign s_video_grant_n = s_tile_gnt_n;
+assign m_tile_grant  = ~m_tile_gnt_n;
+assign s_tile_grant  = ~s_tile_gnt_n;
 assign tile_cpu_addr = s_tile_grant ? s_cpu_addr : m_cpu_addr;
 assign tile_cpu_dsn  = s_tile_grant ? s_cpu_dsn  : m_cpu_dsn;
 assign tile_cpu_dout = s_tile_grant ? s_cpu_dout : m_cpu_dout;
 assign tile_cpu_we   = s_tile_grant ? s_cpu_we   : m_cpu_we;
-assign tilesys_cs    = m_tile_grant | s_tile_grant;
+assign tilesys_cs    = (m_tile_grant & m_tilesys_cs) | (s_tile_grant & s_tilesys_cs);
 assign m_vdtack      = vdtack & m_tile_grant;
 assign s_vdtack      = vdtack & s_tile_grant;
 assign cpu_saddr     = tile_cpu_addr;
@@ -169,6 +177,16 @@ always @(*) begin
     else
         ioctl_din = 8'hff;
 end
+
+jtgrad3_arbiter u_tile_arb(
+    .rst        ( rst          ),
+    .clk        ( clk          ),
+    .cen24      ( cen24        ),
+    .a_req_n    ( ~m_tile_req  ),
+    .b_req_n    ( ~s_tile_req  ),
+    .a_grant_n  ( m_tile_gnt_n ),
+    .b_grant_n  ( s_tile_gnt_n )
+);
 
 jtaliens_scroll u_scroll(
     .rst        ( rst              ),


### PR DESCRIPTION
Issue #1413

This PR models the boards F22, the video-bus arbiter, which the core currenly replaces with a fixed priority that starves the main CPU. Both CPUs share the game state in RAM, so starving one lets them drift out of step under load, and occasionally that drift lands somewhere that kills the ship at random. The request feeding F22 is both of each CPU's video windows, the 052109 and the graphics RAM, as J13A/H22A do on the board; previously only the 052109 window was arbitrated.

Tests are showing that the Game now follows the attracts for both World and JP correctly based on mame and the PS2 version as I cannot find a good video of the PCB attracts. Soaked for 2 hours each. Gameplay has been fine and I haven't seen a phantom death based on my not great skill.