### PR TITLE
Gradius III Audio Filter Model & Balance

### DIFF
--- a/cores/grad3/cfg/mem.yaml
+++ b/cores/grad3/cfg/mem.yaml
@@ -20,8 +20,8 @@ audio:
   rsum: 12k
   rsum_feedback_res: true
   channels:
-    - { name: fm,  module: jt51,     rsum: 3.3k, rc: [ { r: 470,  c: 22n  } ] }
-    - { name: pcm, module: jt007232, rsum: 4.7k, rc: [ { r: 4.7k, c: 4.7n } ], pre: 0.45 }
+    - { name: fm,  module: jt51,     rsum: 5.3k, rc: [ { r: 811,  c: 33n  } ] }
+    - { name: pcm, module: jt007232, rsum: 4.7k, rc: [ { r: 20k,  c: 470p } ], pre: 0.1333 }
 sdram:
   banks:
     - buses:


### PR DESCRIPTION
This fixes the filter to the correct values from the schematic. The 007232's output ladder is a Konami custom with no published resistance so the FM/PCM balance was matched against an audio recording of the PCB ( https://vgmdb.net/album/325 )