### PR TITLE
Gradius III Correctness Fix maybe

### DIFF
--- a/cores/grad3/hdl/jtgrad3_sub.v
+++ b/cores/grad3/hdl/jtgrad3_sub.v
@@ -64,9 +64,9 @@ reg  [ 2:0] irq_mask;
 
 assign rst_cpu   = rst | sub_rst;
 assign lvbln     = ~LVBL;
-assign irq1_clr  = ~irq_mask[0] | ~VPAn;
-assign irq2_clr  = ~irq_mask[1] | ~VPAn;
-assign irq4_clr  = ~irq_mask[2] | ~VPAn;
+assign irq1_clr  = ~irq_mask[0];
+assign irq2_clr  = ~irq_mask[1];
+assign irq4_clr  = ~irq_mask[2];
 assign cpu_addr  = A[19:1];
 assign rom_addr  = A[19:1];
 assign bus_dsn   = { UDSn, LDSn };


### PR DESCRIPTION
On the sub CPU I noticed all three interrupt clears carry ~VPAn, so acknoledging any one interrupt also wipes the other two. The game's own handlers clear only their own mask bit and deliberately leave the others armed. I can't show this changes anything you can see. Just found it while looking at #1413, it doesn't fix that. Happy to drop it if the ~VPAn is there on purpose?