### PR TITLE
Raiga Mixer Fix for #1198

### DIFF
--- a/cores/gaiden/hdl/jtgaiden_blender.v
+++ b/cores/gaiden/hdl/jtgaiden_blender.v
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  * Date: 2-3-2025 */
 
-// blends two colors by simply averaging the RGB signals
+// blends two colors by adding the RGB signals, with saturation
 module jtgaiden_blender(
     input          clk,
     input          latch,
@@ -15,16 +15,16 @@ module jtgaiden_blender(
 
 reg [11:0] mix;
 
-function [3:0] avg(input [3:0]a,b); begin
+function [3:0] sat(input [3:0]a,b); begin
     reg [4:0] sum;
     sum = {1'b0,a}+{1'b0,b};
-    avg = sum[4:1];
+    sat = sum[4] ? 4'hf : sum[3:0];
 end endfunction
 
 always @* begin
-    mix = {avg(main[8+:4],other[8+:4]),
-           avg(main[4+:4],other[4+:4]),
-           avg(main[0+:4],other[0+:4])};
+    mix = {sat(main[8+:4],other[8+:4]),
+           sat(main[4+:4],other[4+:4]),
+           sat(main[0+:4],other[0+:4])};
 end
 
 always @(posedge clk) if(latch) blended <= enable ? mix : main;

--- a/cores/gaiden/hdl/jtgaiden_colmix.vh
+++ b/cores/gaiden/hdl/jtgaiden_colmix.vh
@@ -1,5 +1,6 @@
 localparam [12:1] FILL={SCR1,8'd0};
 
 localparam [3:0] OBJ=0, TEXT=1, SCR1=2, SCR2=3;
-localparam [4:0] SEL_TXT=1,SEL_SCR1=2,SEL_SCR2=4,SEL_OBJ=8,SEL_NONE=16;
+localparam [3:0] BLEND_COMP=4, BLEND_SRC=8;
+localparam [4:0] SEL_BGPEN=0,SEL_TXT=1,SEL_SCR1=2,SEL_SCR2=4,SEL_OBJ=8,SEL_NONE=16;
 localparam [2:0] REGISTER_FINAL_COLOR=6;

--- a/cores/gaiden/hdl/jtgaiden_palmux.v
+++ b/cores/gaiden/hdl/jtgaiden_palmux.v
@@ -18,23 +18,29 @@ module jtgaiden_palmux(
 `include "jtgaiden_colmix.vh"
 
 reg [ 4:0] amuxsel=SEL_NONE;
+reg [ 3:0] bank=0;
 
 always @* begin
     case(amuxsel)
-        SEL_TXT:  pal_addr = {TEXT, txt_pxl};
-        SEL_SCR1: pal_addr = {SCR1, scr1_pxl[7:0]};
-        SEL_SCR2: pal_addr = {SCR2, scr2_pxl};
-        SEL_OBJ:  pal_addr = {OBJ,  obj_pxl[7:0]};
+        SEL_TXT:  pal_addr = {TEXT|bank, txt_pxl};
+        SEL_SCR1: pal_addr = {SCR1|bank, scr1_pxl[7:0]};
+        SEL_SCR2: pal_addr = {SCR2|bank, scr2_pxl};
+        SEL_OBJ:  pal_addr = {OBJ |bank, obj_pxl[7:0]};
+        SEL_BGPEN:pal_addr = {SCR1|BLEND_COMP, 8'd0};
         default:  pal_addr = FILL;
     endcase
 end
 
 always @(posedge clk) begin
     case(st)
-        1: amuxsel <= sel;
+        1: begin
+            amuxsel <= sel;
+            bank    <= sel2!=SEL_NONE ? BLEND_SRC : 4'd0;
+        end
         3: begin
             main    <= pal_dout[11:0];
             amuxsel <= sel2;
+            bank    <= BLEND_COMP;
         end
         5: begin
             other <= pal_dout[11:0];

--- a/cores/gaiden/hdl/jtgaiden_priority.v
+++ b/cores/gaiden/hdl/jtgaiden_priority.v
@@ -38,18 +38,29 @@ always @* begin
              3'b1??: sel = SEL_TXT;
              3'b01?: begin sel = SEL_SCR1; sel2 = sblend ? SEL_OBJ  : SEL_NONE; end
              3'b001: begin sel = SEL_OBJ;  sel2 = oblend ? SEL_SCR2 : SEL_NONE; end
-            default: sel = SEL_OBJ;
+            default: begin sel = SEL_OBJ;  sel2 = oblend ? SEL_BGPEN: SEL_NONE; end
         endcase
         3'b1_10: casez(bgopac)
              3'b1??: sel = SEL_TXT;
              3'b01?: begin sel = SEL_OBJ; sel2 = oblend ? SEL_SCR1 : SEL_NONE; end
              3'b001: begin sel = SEL_OBJ; sel2 = oblend ? SEL_SCR2 : SEL_NONE; end
-            default: sel = SEL_OBJ;
+            default: begin sel = SEL_OBJ; sel2 = oblend ? SEL_BGPEN: SEL_NONE; end
         endcase
-        3'b1_11: sel = SEL_OBJ;
+        3'b1_11: begin
+            sel = SEL_OBJ;
+            if( oblend ) casez(bgopac)
+                 3'b1??: sel2 = SEL_TXT;
+                 3'b01?: sel2 = SEL_SCR1;
+                 3'b001: sel2 = SEL_SCR2;
+                default: sel2 = SEL_BGPEN;
+            endcase
+        end
         3'b0_??: casez(bgopac)
              3'b1??: sel = SEL_TXT;
-             3'b01?: sel = SEL_SCR1;
+             3'b01?: begin
+                sel  = SEL_SCR1;
+                sel2 = !sblend ? SEL_NONE : scr2_bn ? SEL_SCR2 : SEL_BGPEN;
+             end
              3'b001: sel = SEL_SCR2;
             default: sel = SEL_NONE;
         endcase


### PR DESCRIPTION
Fixes #1198 and the worm level

Tested all games on this core and no visual regressions from what I can see. - Ninja Gaiden uses this blend trick too for enemy deaths and looks like the PCB based on YT recordings. Wild Fang doesn't use it.

The board keeps three copies of the palette. The normal colours, the colours a pixel shows when something blended sits in front of it, and the colours the blended thing itself adds. A blended pixel is the last two added together.

The core only ever read the normal copy, and averaged the two colours 50/50. So two thirds of the palette RAM was being written by the game and never read, and the game had no control over how transparent anything was.

With a flat 50/50 the planet came through the letters and the title 'show and hide' band shows through the planet.

Based on mame priority table. Palette Layout from the scene dumps.