### PR TITLE
ci(affected-cores): make PAT optional, add job summary fallback

### DIFF
--- a/.github/workflows/affected-cores.yaml
+++ b/.github/workflows/affected-cores.yaml
@@ -33,8 +33,11 @@ jobs:
               url."https://x-access-token:${PAT}@github.com/".insteadOf \
               "git@github.com:"
           fi
-          git submodule update --init --recursive 2>&1 || \
-            echo "::warning::Some submodules could not be cloned (private repos need PAT)"
+          git submodule init
+          for sm in $(git config --file .gitmodules --get-regexp path | awk '{print $2}'); do
+            git submodule update --init --recursive -- "$sm" 2>&1 || \
+              echo "::warning::Skipped submodule $sm"
+          done
         env:
           PAT: ${{ secrets.PAT }}
           GIT_TERMINAL_PROMPT: '0'

--- a/.github/workflows/affected-cores.yaml
+++ b/.github/workflows/affected-cores.yaml
@@ -24,10 +24,20 @@ jobs:
 
       - uses: actions/checkout@v5
         with:
-          submodules: recursive
-          token: ${{ secrets.PAT }}
-          persist-credentials: false
           fetch-depth: 0
+
+      - name: Initialize submodules
+        run: |
+          if [ -n "$PAT" ]; then
+            git config --global \
+              url."https://x-access-token:${PAT}@github.com/".insteadOf \
+              "git@github.com:"
+          fi
+          git submodule update --init --recursive 2>&1 || \
+            echo "::warning::Some submodules could not be cloned (private repos need PAT)"
+        env:
+          PAT: ${{ secrets.PAT }}
+          GIT_TERMINAL_PROMPT: '0'
 
       - name: Build JTFRAME CLI
         env:
@@ -59,9 +69,11 @@ jobs:
         with:
           repository-path: .
           changed-files: ${{ steps.changed-files.outputs.result }}
+          skip-submodules: modules/jt900h,modules/jtframe/target/pocket,modules/jt680x/crasm
 
       - name: Find existing comment
         id: find-comment
+        continue-on-error: true
         uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
         with:
           token: ${{ github.token }}
@@ -71,7 +83,8 @@ jobs:
           direction: first
 
       - name: Create affected-cores comment
-        if: steps.find-comment.outputs.comment-id == 0
+        if: steps.find-comment.outcome == 'success' && steps.find-comment.outputs.comment-id == 0
+        continue-on-error: true
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           token: ${{ github.token }}
@@ -79,7 +92,8 @@ jobs:
           body: ${{ steps.analyze.outputs.pull-request-comment }}
 
       - name: Update affected-cores comment
-        if: steps.find-comment.outputs.comment-id != 0
+        if: steps.find-comment.outcome == 'success' && steps.find-comment.outputs.comment-id != 0
+        continue-on-error: true
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           token: ${{ github.token }}


### PR DESCRIPTION
- Remove hard PAT requirement from checkout; init submodules manually with SSH→HTTPS rewrite only when PAT is available
- Pass skip-submodules for the three SSH-only repos (jt900h, pocket, crasm)
- PR comment steps use continue-on-error so missing write permissions (fork PRs) don't fail the job — jtcheck already writes GITHUB_STEP_SUMMARY

Closes #1573