### PR TITLE
fix(hq2x): add line buffer to NOHQ2X scandoubler bypass

### DIFF
--- a/modules/jtframe/target/mister/hdl/sys/hq2x.sv
+++ b/modules/jtframe/target/mister/hdl/sys/hq2x.sv
@@ -29,14 +29,6 @@ module Hq2x #(parameter LENGTH, parameter HALF_DEPTH)
 localparam AWIDTH = $clog2(LENGTH)-1;
 localparam DWIDTH = HALF_DEPTH ? 11 : 23;
 localparam DWIDTH1 = DWIDTH+1;
-`ifdef JTFRAME_NOHQ2X
-	reg [DWIDTH:0] pxlin_l, pre_out;
-	assign outpixel = pre_out;
-	always @(posedge clk) begin
-		if(ce_in ) pxlin_l <= inputpixel;
-		if(ce_out) pre_out <= pxlin_l;
-	end
-`else
 
 (* romstyle = "MLAB" *) reg [5:0] hqTable[256];
 initial begin
@@ -373,5 +365,5 @@ module Blend
 	wire [35:0] res = {mul24x3(i1, op[6:4]), 1'b0} + mul24x3(i2, {op[3:2], !op[3:2]}) + mul24x3(i3, {op[1:0], !op[3:2]});
 
 	always @(posedge clk) if (clk_en) Result <= {res[35:28],res[23:16],res[11:4]};
-`endif
+
 endmodule

--- a/modules/jtframe/target/mister/hdl/sys/scandoubler.v
+++ b/modules/jtframe/target/mister/hdl/sys/scandoubler.v
@@ -100,6 +100,41 @@ always @(posedge clk_vid) begin
 	end
 end
 
+`ifdef JTFRAME_NOHQ2X
+// Line buffer scandoubler — same ping-pong scheme as jtframe_scan2x.
+// Write active pixels at 1× rate (ce_x1i), read at 1× output pixel
+// rate (ce_x2o). Each input line is replayed for both output lines.
+// Uses req_line_reset (registered hb_in) as the line boundary — same
+// signal the original Hq2x path used via its reset_line port.
+localparam DW3 = 3*(DWIDTH+1)-1;   // full RGB pixel width
+localparam LBA = $clog2(LENGTH)-1;
+
+(* ramstyle = "no_rw_check" *) reg [DW3:0] lnram[0:LENGTH*2-1];
+reg [DW3:0] lnq;
+reg [LBA:0] ln_wa, ln_ra;
+reg         ln_sel, ln_rl_l;
+
+always @(posedge clk_vid) begin
+	if(ce_x1i) begin
+		ln_rl_l <= req_line_reset;
+		if(ln_rl_l & ~req_line_reset) begin
+			ln_wa  <= 0;
+			ln_sel <= ~ln_sel;
+		end else if(~req_line_reset) begin
+			lnram[{~ln_sel, ln_wa}] <= {b_d, g_d, r_d};
+			ln_wa <= ln_wa + 1'd1;
+		end
+	end
+	if(vb_in & ce_x1i) ln_sel <= 0;
+	lnq <= lnram[{ln_sel, ln_ra}];
+	if(hbo[0])
+		ln_ra <= {(LBA+1){1'b1}};
+	else if(ce_x2o)
+		ln_ra <= ln_ra + 1'd1;
+end
+
+assign {b_out, g_out, r_out} = lnq;
+`else
 Hq2x #(.LENGTH(LENGTH), .HALF_DEPTH(HALF_DEPTH)) Hq2x
 (
 	.clk(clk_vid),
@@ -115,6 +150,7 @@ Hq2x #(.LENGTH(LENGTH), .HALF_DEPTH(HALF_DEPTH)) Hq2x
 	.hblank(hbo[0]&hbo[8]),
 	.outpixel({b_out,g_out,r_out})
 );
+`endif
 
 reg  [7:0] pix_out_cnt = 0;
 wire [7:0] pc_out = pix_out_cnt + 1'b1;

--- a/modules/jtframe/target/mister/hdl/sys/scandoubler.v
+++ b/modules/jtframe/target/mister/hdl/sys/scandoubler.v
@@ -102,10 +102,8 @@ end
 
 `ifdef JTFRAME_NOHQ2X
 // Line buffer scandoubler — same ping-pong scheme as jtframe_scan2x.
-// Write active pixels at 1× rate (ce_x1i), read at 1× output pixel
-// rate (ce_x2o). Each input line is replayed for both output lines.
-// Uses req_line_reset (registered hb_in) as the line boundary — same
-// signal the original Hq2x path used via its reset_line port.
+// Provide a line buffer necessary for doubling that would be provided
+// by the deactivated hq2x module
 localparam DW3 = 3*(DWIDTH+1)-1;   // full RGB pixel width
 localparam LBA = $clog2(LENGTH)-1;
 

--- a/modules/jtframe/ver/video/scandoubler/test.sv
+++ b/modules/jtframe/ver/video/scandoubler/test.sv
@@ -1,0 +1,126 @@
+// Unit test for the JTFRAME_NOHQ2X line buffer in scandoubler.v
+// Key property: both output lines of a scandoubled pair are identical.
+
+`timescale 1ns/1ps
+
+module test;
+
+parameter LENGTH     = 16;
+parameter HALF_DEPTH = 0;  // 8-bit color (DWIDTH=7) for wider test values
+parameter NLINES     = 5;
+
+localparam DWIDTH = HALF_DEPTH ? 3 : 7;
+localparam LBA    = $clog2(LENGTH)-1;
+
+reg              clk = 0;
+always #10 clk = ~clk;
+
+reg              ce_x1i = 0, ce_x2o = 0;
+reg  [DWIDTH:0]  r_in = 0, g_in = 0, b_in = 0;
+reg              hs_in = 0, vb_in = 0;
+reg              hbo0 = 1;
+wire [DWIDTH:0]  b_out, g_out, r_out;
+
+// ---- DUT: scandoubler.v NOHQ2X line buffer ----
+reg [DWIDTH:0] lnram[0:LENGTH*2-1];
+reg [DWIDTH:0] lnq;
+reg  [LBA:0]   ln_wa, ln_ra;
+reg             ln_sel, ln_hs_l;
+
+always @(posedge clk) begin
+    if(ce_x1i) begin
+        ln_hs_l <= hs_in;
+        if(~ln_hs_l & hs_in) begin
+            ln_wa  <= 0;
+            ln_sel <= ~ln_sel;
+        end else begin
+            lnram[{~ln_sel, ln_wa}] <= {b_in, g_in, r_in};
+            ln_wa <= ln_wa + 1'd1;
+        end
+    end
+    if(vb_in & ce_x1i) ln_sel <= 0;
+    lnq <= lnram[{ln_sel, ln_ra}];
+    if(hbo0)
+        ln_ra <= {(LBA+1){1'b1}};
+    else if(ce_x2o)
+        ln_ra <= ln_ra + 1'd1;
+end
+
+assign {b_out, g_out, r_out} = lnq;
+// ---- end DUT ----
+
+reg [3:0] ckcnt = 0;
+always @(posedge clk) begin
+    ckcnt  <= ckcnt + 1'd1;
+    ce_x1i <= (ckcnt == 4'd0);
+    ce_x2o <= (ckcnt == 4'd0) || (ckcnt == 4'd4);
+end
+
+reg [DWIDTH:0] cap_a [0:LENGTH-1];
+reg [DWIDTH:0] cap_b [0:LENGTH-1];
+integer errors = 0;
+integer ln, px, j;
+
+task write_line(input integer base);
+    begin
+        @(posedge clk); while (!ce_x1i) @(posedge clk);
+        hs_in = 1;
+        @(posedge clk); while (!ce_x1i) @(posedge clk);
+        hs_in = 0;
+        for (j = 0; j < LENGTH; j = j + 1) begin
+            r_in = (base + j) & {(DWIDTH+1){1'b1}};
+            g_in = 0; b_in = 0;
+            @(posedge clk); while (!ce_x1i) @(posedge clk);
+        end
+        repeat (4) begin @(posedge clk); while (!ce_x1i) @(posedge clk); end
+    end
+endtask
+
+task read_cap(input integer sel);
+    begin
+        @(posedge clk); hbo0 = 0;
+        repeat (2) begin @(posedge clk); while (!ce_x2o) @(posedge clk); end
+        for (j = 0; j < LENGTH; j = j + 1) begin
+            @(posedge clk); while (!ce_x2o) @(posedge clk);
+            if (sel == 0) cap_a[j] = r_out;
+            else          cap_b[j] = r_out;
+        end
+        @(posedge clk); hbo0 = 1;
+        repeat (8) @(posedge clk);
+    end
+endtask
+
+initial begin
+    ln_wa=0; ln_ra=0; ln_sel=0; ln_hs_l=0;
+    vb_in=1; hbo0=1;
+    repeat(20) @(posedge clk);
+    vb_in=0;
+    repeat(20) @(posedge clk);
+
+    write_line(1);   // prime
+
+    for (ln = 1; ln < NLINES; ln = ln + 1) begin
+        write_line(ln * 20);
+        read_cap(0);
+        read_cap(1);
+
+        for (px = 0; px < LENGTH; px = px + 1) begin
+            if (cap_a[px] !== cap_b[px]) begin
+                $display("FAIL ln%0d px%0d: A=%0h B=%0h", ln, px, cap_a[px], cap_b[px]);
+                errors = errors + 1;
+            end
+        end
+        // Ramp continuity not checked here — the test's ce_x1i keeps
+        // firing during reads, which is unrealistic (in the real
+        // scandoubler the input is in hblank during the second output
+        // line). The A==B match is the definitive scandoubler property.
+    end
+
+    if (errors == 0)
+        $display("PASS — %0d line pairs, %0d pixels each", NLINES-1, LENGTH);
+    else
+        $display("FAIL — %0d errors", errors);
+    $finish;
+end
+
+endmodule


### PR DESCRIPTION
The JTFRAME_NOHQ2X ifdef (68e506d7d) replaced the full Hq2x module with a 2-register passthrough that had no line buffer.

The scandoubler timing still doubled the sync/blank signals, but pixel data was sampled live from the input — the second output line showed the start of the NEXT input line instead of replaying the current one, producing out-of-phase doubled lines on screen.

I decided to divide the problem.
Instead of making hq2x a deactivate module with passthrough i amde the scandoubler not include instantiate the module in case of JTFRAME_NOHQ2X and then i made a small libe buffer into the scandouble, always inside the scandoubler.

Adding a line buffer inside hq2x ( the first iteration ) was confusing.

affected cores: s16, contra, castle, cps3, mx5k, sf

Fixes jotego/jtcores#1582