### PR TITLE
Grad3: Fixes #1583

### DIFF
--- a/cores/grad3/hdl/jtgrad3_sub.v
+++ b/cores/grad3/hdl/jtgrad3_sub.v
@@ -152,7 +152,7 @@ jtframe_okdly #(.W(3)) u_okdly(
 jtgrad3_int u_int(
     .rst      ( rst_cpu          ),
     .clk      ( clk              ),
-    .LVBL     ( LVBL             ),
+    .LVBL     ( ~LVBL            ),
     .cpu_trig ( cpu_trig         ),
     .din      ( cpu_dout[10:8]   ),
     .wr       ( irq_mask_cs      ),


### PR DESCRIPTION
Fixes #1583

A fix for the slow stage 4.  The sub CPU's level 1 and level 2 are on the wrong VBLK edges. The sub now feeds ~LVBL into jtgrad3_int, so it takes level 1 at the start of blanking and level 2 at the end. The master and jtgrad3_int are unchanged. Stage 4 is 47s again, same as the PCB.

This doesn't follow the schematics as drawn. on the sub sheet they have level 1 (L11A) on ~VBLK and level 2 (L11B) on VBLK through K11E. The master sheet matches MAME, but the sub sheet is the other way round from it: MAME has the sub's level 1 at line 240 and level 2 at line 16. With this change it lines up with MAME exactly (which works at tehe correct speed here) My private core also followed the schematics and gets the same 77 seconds, so the schematics might have the two swapped on the sub?

@skutis , if you still has the board,

On the sub, is L11A pin 3 really on ~VBLK, and L11B pin 11 on K11 pin 10? Or are they the other way round? curious to know

I've tried these fixes for this..

F22, the new cache and turbo ruled out by bisect.
Flipped the CPU triggered interrupt polarity: 77s.
Gated main CPU sub_irq with dws: 77s.
IPL priority encoder in jtgrad3_int: 77s.
Reverted 7b735832e on current master: 47s.
Putting back the sprite timed level 2 (sub_irq2) removed in 7b735832e: 47s. (not keen)
LVBL polarity reversed in jtgrad3_int, so both CPUs: 77s.
Keeping 7b735832e and swapping the sub's level 1 and 2 only: 47s. (winner winner)

Full play through tests fine.