### PR TITLE
Grad3: Fixes #1585

### DIFF
--- a/cores/grad3/hdl/jtgrad3_colmix.v
+++ b/cores/grad3/hdl/jtgrad3_colmix.v
@@ -72,7 +72,7 @@ always @(posedge clk) begin
         rgb <= 0;
     end else if(pxl_cen) begin
         pal_rd_addr <= pal_addr;
-        shl <= shd;
+        shl <= shd | en_b;
         rgb <= shl ? palrd_dout[14:0] : dim(palrd_dout[14:0]);
     end
 end


### PR DESCRIPTION
Fixes #1585

The Mega Crush flash writes white to palette 0x400, the backdrop. The PROM (J28 O3) sets the dim for every pixel with no layer on it, so the core halves it and the flash comes out mid grey. The PCB and MAME show white. This stops the backdrop being dimmed. Sprite shadows are untouched.

0x400 is black everywhere else in the game (checked in MAME through attract, all 12 stages and save states) so the flash is the only place this shows, it never draws a shadow either, I can see logged. only writes at 0 on boot. 

This doesn't follow the schematics as drawn, they run the dim (H26 pin 12 to C22A/B/C, 100R pull downs on the 052535 outputs) on the bcakdrop too. Going by the 052535 sheet that pull down would leave somewhere between a third and two thrids of the brightness depending on the monitor, not white, and the PCB flash is white. So the schematics might have an error there maybe? unless im reading it wrong.

@skutis 

Does H26 pin 12 really go to C22 pins 1, 3 and 5?
With a scope on C22 pin 1, is it low on the black background?
Curious.

I've tried these:

Zeroing the palette address when no layer is on (~CDEN): still grey.
Not dimming the backdrop: white, same as the PCB. (winner winner)

Full play through tests fine