### PR TITLE
Harier: Fix Enduro PCM sample rate on YM2151

### DIFF
--- a/cores/harier/cfg/mem.yaml
+++ b/cores/harier/cfg/mem.yaml
@@ -10,7 +10,7 @@ clocks:
       gate: [ pcm ]
       outputs:
         - cen_pcm
-        - cen_pcm8    # 8 MHz, 315-5218 on the YM2151 board
+        - cen_pcm8    # 315-5218 step rate on the YM2151 board, as in Out Run
     - freq: 8M
       outputs:
         - cen_mcu

--- a/cores/harier/cfg/mem.yaml
+++ b/cores/harier/cfg/mem.yaml
@@ -10,6 +10,7 @@ clocks:
       gate: [ pcm ]
       outputs:
         - cen_pcm
+        - cen_pcm8    # 8 MHz, 315-5218 on the YM2151 board
     - freq: 8M
       outputs:
         - cen_mcu

--- a/cores/harier/hdl/jtharier_game.v
+++ b/cores/harier/hdl/jtharier_game.v
@@ -233,6 +233,7 @@ jtharier_sound u_snd(
     .cen_fm     ( cen_fm        ),  // 4 MHz
     .cen_fm2    ( cen_fm2       ),  // 2 MHz
     .cen_pcm    ( cen_pcm       ),
+    .cen_pcm8   ( cen_pcm8      ),
 
     .latch      ( snd_latch     ),
     .nmi_n      ( snd_nmin      ),

--- a/cores/harier/hdl/jtharier_sound.v
+++ b/cores/harier/hdl/jtharier_sound.v
@@ -10,7 +10,7 @@ module jtharier_sound(
     input                cen_fm,    // 4 MHz, YM2203 (sheet D-2/3, pin 38 OM from 4M)
     input                cen_fm2,   // 2 MHz, YM2151 internal timing
     input                cen_pcm,   // 16 MHz -- NOT 8. See the PCM section below.
-    input                cen_pcm8,  //  8 MHz, 315-5218 on the YM2151 board
+    input                cen_pcm8,  // 315-5218 step rate on the YM2151 board, as in Out Ru
 
     // Main CPU interface via PPI0, CPU sheet 2/6
     input        [ 7:0]  latch,     // PPI0 port A, written by the 68000

--- a/cores/harier/hdl/jtharier_sound.v
+++ b/cores/harier/hdl/jtharier_sound.v
@@ -10,6 +10,7 @@ module jtharier_sound(
     input                cen_fm,    // 4 MHz, YM2203 (sheet D-2/3, pin 38 OM from 4M)
     input                cen_fm2,   // 2 MHz, YM2151 internal timing
     input                cen_pcm,   // 16 MHz -- NOT 8. See the PCM section below.
+    input                cen_pcm8,  //  8 MHz, 315-5218 on the YM2151 board
 
     // Main CPU interface via PPI0, CPU sheet 2/6
     input        [ 7:0]  latch,     // PPI0 port A, written by the 68000
@@ -154,10 +155,11 @@ jt51 u_jt51(
 // sharrier's PCM is not exactly OutRun's. It is a discrete IC implementation
 // Expanding the internal bit width of the channels in jtoutrun_pcm makes it
 // compatible. Otherwise, it would clip the sound.
+// 256 cen per sample: 16M -> 62.5 kHz (discrete), 8M -> 31.25 kHz (315-5218)
 jtoutrun_pcm #(.WD(16)) u_pcm(
     .rst        ( snd_rst     ),
     .clk        ( clk         ),
-    .cen        ( ym2151 ? cen_fm : cen_pcm ),
+    .cen        ( ym2151 ? cen_pcm8 : cen_pcm ),
 
     .cpu_addr   ( A[7:0]      ),
     .cpu_dout   ( cpu_dout    ),


### PR DESCRIPTION
YM2151 versions of Enduro racer were playing an octave low, the PCM clock is now 8 MHz, giving a 31.25 kHz sample rate. sounds correct now.