### PR TITLE
fix(jtframe): T80 let a pending INT in during NMI entry after EI

### DIFF
--- a/modules/jtframe/hdl/cpu/t80/T80.vhd
+++ b/modules/jtframe/hdl/cpu/t80/T80.vhd
@@ -1223,7 +1223,11 @@ begin
 							(I_BTR and (not IR(4) or F(Flag_Z)));
 					if TState = 2 then
 						if SetEI = '1' then
-							IntE_FF1 <= '1';
+							-- EI lands here, at T2 of the next M1. If that M1 is an NMI
+							-- taken right after EI, IFF1 must stay clear until RETN.
+							if NMICycle = '0' then
+								IntE_FF1 <= '1';
+							end if;
 							IntE_FF2 <= '1';
 						end if;
 						if I_RETN = '1' then

--- a/modules/jtframe/hdl/cpu/t80/T80s.v
+++ b/modules/jtframe/hdl/cpu/t80/T80s.v
@@ -20358,7 +20358,7 @@ module t80_0_1_0_1_2_3_4_5_6_7
   /* T80.vhd:1224:51  */
   assign n1815_o = tstate == 3'b010;
   /* T80.vhd:1225:49  */
-  assign n1817_o = setei ? 1'b1 : inte_ff1;
+  assign n1817_o = (setei & ~nmicycle) ? 1'b1 : inte_ff1;
   /* T80.vhd:1224:41  */
   assign n1819_o = n1822_o ? 1'b1 : inte_ff2;
   /* T80.vhd:1229:49  */


### PR DESCRIPTION
Found on the Hang-On sound board: its IM1 handler ends EI/RET and the 68000 streams commands over NMI, so one late NMI dropped a command byte and broke the sound until reset. Captured over JTAG, then reproduced with T80s.v in a small bench (INT held low, EI/RET handler, NMI phase swept): 199 of 1500 NMIs ran the INT handler first before the fix, 0 after.

EI's enable is written at T2 of the next M1, while IR still holds EI. When that M1 is the acknowledge of an NMI taken right after EI, the late write undoes the NMI's IFF1 clear. With INT pending, the T80 then runs an INT acknowledge at 0x0066 instead of the first instruction of the NMI handler. Zilog documents IFF1 staying clear from NMI entry until RETN.

The IFF1 set is now skipped during the NMI cycle. IFF2 is still set, so RETN restores IFF1. T80s.v gets the same one-line change.
