### PR TITLE
harier: Adds hang-on

### DIFF
--- a/cores/harier/README.md
+++ b/cores/harier/README.md
@@ -21,4 +21,7 @@ Enduro Racer uses both analog sticks. The left stick horizontal axis steers,
 and its vertical axis controls the motorcycle bank. The right stick vertical
 axis is split into pedals: up accelerates and down brakes.
 
-The current version only supports a dual-stick analog controller for Enduro Racer. That will be improved soon.
+Hang-On uses the left stick horizontal axis to steer. The right stick vertical
+axis is split into pedals: up accelerates and down brakes.
+
+The current version only supports a dual-stick analog controller for Enduro Racer and Hang-On. That will be improved soon.

--- a/cores/harier/cfg/mame2mra.toml
+++ b/cores/harier/cfg/mame2mra.toml
@@ -4,9 +4,7 @@ author=["jotego","niknak"]
 [parse]
 sourcefile=[ "segahang.cpp" ]
 main_setnames=["sharrier"]
-# Hang-On's sprite ROMs do not group into 32-bit words, so its sprite format is
-# not implemented.
-skip={ bootlegs=true, machines=["hangon","shangon"] }
+skip={ bootlegs=true, machines=["shangon"] }
 
 [audio]
 volume = [ { machine="sharrier", value = 160 } ]
@@ -36,6 +34,7 @@ registers=[
     { name="i8751",  pos="0[0]",  desc="i8751 MCU", values=[{ machine="sharrier", value=1 }] },
     { name="fd1089", pos="0[1]",  desc="FC1089B",   values=[{ machine="enduror",  value=1 }] },
     { name="blank4", pos="0[2]",  desc="IPL2 set at blank", values=[{machines=["enduror","hangon"], value=1}] },
+    { name="hangon", pos="0[3]",  desc="Hang-On board", values=[{ machine="hangon", value=1 }] },
     { name="ym2151", pos="1[0]",  desc="YM2151",      values=[{setname="enduror1", value=0},{machine="enduror", value=1}]},
     { name="cab1p",  pos="2[0]",  desc="1P at bit 6", values=[{machine="enduror",  value=1}]},
     { name="hicol",  pos="3[0]",  desc="6144 colors", values=[{machine="hangon",   value=1}]},
@@ -50,6 +49,7 @@ regions = [
     { name="pcm",          start="PCM_START" },
     { name="gfx1",         start="JTFRAME_BA2_START", width=32, sequence=[0,1,2,2] },
     { name="sprites",      start="JTFRAME_BA3_START", width=32, no_offset=true },
+    { name="sprites",      start="JTFRAME_BA3_START", width=16, no_offset=true, machine="hangon" },
     { name="segaic16road", start="ROAD_START", width=16, no_offset=true, singleton=true },
     { name="sprites:zoom", start="ZOOM_START", len=0x2000 },
     { name="mcu",          start="MCU_START", len=0x1000 },

--- a/cores/harier/cfg/mem.yaml
+++ b/cores/harier/cfg/mem.yaml
@@ -45,6 +45,8 @@ sdram:
         - { name: map2,   addr_width: 16, data_width: 16, offset: VRAM_OFFSET, cs: gfx_cs }
     - buses:
         - { name: subrom, addr_width: 16, data_width: 16, cache_size: 1kB }
+        # Hang-On: the main CPU reads the sub ROM at c00000
+        - { name: subrom2, addr_width: 16, data_width: 16, addr: "main_addr[15:1]", cs: subrom_cs_main }
         - { name: snd,    addr_width: 15, data_width:  8, offset: SND_OFFSET, cache_size: 1kB }
         - { name: pcm,    addr_width: 19, data_width:  8, offset: PCM_OFFSET }
     - buses:

--- a/cores/harier/hdl/jtharier_cab.v
+++ b/cores/harier/hdl/jtharier_cab.v
@@ -106,6 +106,10 @@ always @(posedge clk) begin
             end else begin
                 an_x <= an_x_raw;
                 an_y <= an_y_raw;
+                if( adc==3'd3 ) begin      // Hang-On pedals swing 00-FF
+                    an_gas   <= enduro_gas[7]   ? 8'hff : { enduro_gas[6:0],   1'b0 };
+                    an_brake <= enduro_brake[7] ? 8'hff : { enduro_brake[6:0], 1'b0 };
+                end
             end
         end
     end

--- a/cores/harier/hdl/jtharier_colmix.v
+++ b/cores/harier/hdl/jtharier_colmix.v
@@ -25,6 +25,8 @@ module jtharier_colmix(
     output     [10:0]  pal_addr,
     input      [15:0]  pal_data,
     input              shadow,
+    input              hicol,     // Hang-On: shadow/hilight set by SHADER, not pal_data[15]
+    input              shade0,
 
     output     [ 4:0]  red,
     output     [ 4:0]  green,
@@ -55,10 +57,22 @@ function [4:0] dim;
     dim = a - (a>>2);
 endfunction
 
+// hilight: SHADER high through 470 ohm
+function [4:0] lit;
+    input [4:0] a;
+    lit = dim(a) + 5'd7;
+endfunction
+
 // SHADE from 315-5171, sheet 6/7.
+// Hang-On: SHADER low shadows, high hilights
 always @(*) begin
-    rgb_shade = (shadow & ~pal_data[15]) ? { dim(rpal), dim(gpal), dim(bpal) } :
-                                           {     rpal,      gpal,      bpal  };
+    if( hicol )
+        rgb_shade = !shadow ? { rpal, gpal, bpal } :
+                    shade0  ? { lit(rpal), lit(gpal), lit(bpal) } :
+                              { dim(rpal), dim(gpal), dim(bpal) };
+    else
+        rgb_shade = (shadow & ~pal_data[15]) ? { dim(rpal), dim(gpal), dim(bpal) } :
+                                               {     rpal,      gpal,      bpal  };
     if( !video_en ) rgb_shade = 0;
 end
 

--- a/cores/harier/hdl/jtharier_dtack_cen.v
+++ b/cores/harier/hdl/jtharier_dtack_cen.v
@@ -5,6 +5,7 @@
 module jtharier_dtack_cen(
     input         rst,
     input         clk,
+    input         hangon,
     output        cpu_cen,
     output        cpu_cenb,
     input         UDSn, LDSn,
@@ -20,6 +21,10 @@ module jtharier_dtack_cen(
     output  [15:0] fworst  // average cpu_cen frequency in kHz
 );
 
+// Hang-On runs both 68000s from the video master, 25.1748/4 = clk/8
+wire [8:0] num = hangon ?  9'd1 :  9'd173;
+wire [9:0] den = hangon ? 10'd8 : 10'd871;
+
 jtframe_68kdtack_cen #(.W(10)) u_dtack(
     .rst        ( rst         ),
     .clk        ( clk         ),
@@ -31,8 +36,8 @@ jtframe_68kdtack_cen #(.W(10)) u_dtack(
     .bus_ack    ( 1'b0        ),
     .ASn        ( ASn         ),
     .DSn        ( {UDSn,LDSn} ),
-    .num        ( 9'd173      ),
-    .den        ( 10'd871     ),
+    .num        ( num         ),
+    .den        ( den         ),
     .wait2      ( 1'b0        ),
     .wait3      ( 1'b0        ),
     .DTACKn     ( DTACKn      ),

--- a/cores/harier/hdl/jtharier_game.v
+++ b/cores/harier/hdl/jtharier_game.v
@@ -17,14 +17,14 @@ wire        main_rnw, ram_cs, char_cs_main, objram_cs_main,
 wire [15:0] char_dout;
 wire [ 1:0] sub_dsn;
 wire        sub_rnw, sub_ram_cs, sub_road_cs, sub_rstn, sub_intn;
-wire        flip, video_en, colscr_en, rowscr_en;
+wire        flip, video_en, shade0, colscr_en, rowscr_en;
 wire        snd_rstn;   // PPI0 port B bit 5, Z80 /RESET (active low)
 wire [ 7:0] snd_latch;
 wire        snd_ack;
 wire        snd_nmin;
 wire [ 8:0] vrender, hdump;
 wire [ 7:0] dipsw_a, dipsw_b, st_main, st_sub, st_video, st_road;
-wire        scr_bad, i8751, fd1089, blank4, ym2151, cab1p, hicol;
+wire        scr_bad, i8751, fd1089, blank4, hangon, ym2151, cab1p, hicol;
 wire [12:0] key_addr;
 wire [ 7:0] key_data;
 wire [ 2:0] adc;        // number of ADC channels
@@ -61,6 +61,7 @@ jtharier_header u_header(
     .i8751      ( i8751          ),
     .fd1089     ( fd1089         ),
     .blank4     ( blank4         ),
+    .hangon     ( hangon         ),
     .ym2151     ( ym2151         ),
     .cab1p      ( cab1p          ),
     .hicol      ( hicol          ),
@@ -126,6 +127,7 @@ jtharier_main u_main(
     .i8751       ( i8751           ),
     .fd1089      ( fd1089          ),
     .blank4      ( blank4          ),
+    .hangon      ( hangon          ),
     .cab1p       ( cab1p           ),
     .adc         ( adc             ),
     .LVBL        ( LVBL            ),
@@ -160,6 +162,9 @@ jtharier_main u_main(
     .rom_cs      ( main_cs         ),
     .rom_data    ( main_data       ),
     .rom_ok      ( main_ok         ),
+    .subrom_cs   ( subrom_cs_main  ),
+    .subrom_data ( subrom2_data    ),
+    .subrom_ok   ( subrom2_ok      ),
 
     .dipsw_a     ( dipsw_a         ),
     .dipsw_b     ( dipsw_b         ),
@@ -181,12 +186,14 @@ jtharier_main u_main(
     .snd_rstn    ( snd_rstn        ),
     .snd_ack     ( snd_ack         ),
     .video_en    ( video_en        ),
+    .shade0      ( shade0          ),
     .colscr_en   ( colscr_en       ),
     .rowscr_en   ( rowscr_en       ),
 
     .subram_cs   ( subram_cs_main  ),
     .roadram_cs  ( roadram_cs_main ),
     .subram_dout ( subram_dout     ),
+    .road_dout   ( roadram_dout    ),
 
     .sub_rstn    ( sub_rstn        ),
     .sub_intn    ( sub_intn        ),
@@ -202,6 +209,7 @@ jtharier_main u_main(
 jtharier_sub u_sub(
     .rst        ( rst          ),
     .clk        ( clk          ),
+    .hangon     ( hangon       ),
 
     .rstn       ( sub_rstn     ),
     .intn       ( sub_intn     ),
@@ -266,6 +274,9 @@ jtharier_video u_video(
     .colscr_en   ( colscr_en       ),
     .rowscr_en   ( rowscr_en       ),
     .vfix_en     ( vfix_en         ),
+    .hangon      ( hangon          ),
+    .hicol       ( hicol           ),
+    .shade0      ( shade0          ),
 
     .dip_pause   ( dip_pause       ),
     .char_cs     ( char_cs_main    ),

--- a/cores/harier/hdl/jtharier_main.v
+++ b/cores/harier/hdl/jtharier_main.v
@@ -8,6 +8,7 @@ module jtharier_main(
     input              i8751,
     input              fd1089,
     input              blank4,
+    input              hangon,
     input              cab1p,
     input       [ 2:0] adc,
     output      [12:0] key_addr,
@@ -32,6 +33,7 @@ module jtharier_main(
     input       [15:0] objram_dout,
     input       [15:0] pal_dout,
     input       [15:0] subram_dout,
+    input       [15:0] road_dout,
 
     // Work RAM, IC96/IC83 on CPU sheet 1/6
     output reg         ram_cs,
@@ -46,6 +48,10 @@ module jtharier_main(
     output reg         rom_cs,
     input       [15:0] rom_data,
     input              rom_ok,
+    // Hang-On: sub CPU ROM at c00000
+    output reg         subrom_cs,
+    input       [15:0] subrom_data,
+    input              subrom_ok,
 
     input       [ 7:0] dipsw_a,
     input       [ 7:0] dipsw_b,
@@ -62,6 +68,7 @@ module jtharier_main(
     output             flip,
     output reg         mute,
     output             video_en,
+    output             shade0,
     output             colscr_en,   // SCONT1: column-scroll enable to the tilemap
     output             rowscr_en,   // SCONT0: row-scroll enable to the tilemap
     // sound
@@ -92,7 +99,7 @@ wire        BRn, BGn, BGACKn;
 wire [15:0] cpu_dout_raw;
 reg  [15:0] cpu_din;
 reg  [ 7:0] cab_dout, io_dout;
-wire        rom_ok_dly, vram_ok_dly, sound_en, fd1089_ok;
+wire        rom_ok_dly, vram_ok_dly, subrom_ok_dly, sound_en, fd1089_ok;
 wire [15:0] fd1089_dec;
 wire [15:0] rom_dec = fd1089 ? fd1089_dec : rom_data;
 wire [ 7:0] ppi0_dout, ppi1_dout, ppi0_b, ppi0_c, ppi1_a;
@@ -112,6 +119,7 @@ reg         mcu_rst, fd1089_rst;
 
 assign      lvbl_g   = dip_pause ? LVBL : 1'b1;
 assign      video_en = ppi0_b[4];
+assign      shade0   = ppi0_b[6];     // SHADER: 0 shadow, 1 hilight
 wire [ 1:0] scont    = ppi0_c[2:1];   // {SCONT1, SCONT0}, active low
 assign      colscr_en = ~scont[1];    // = ~ppi0_c[2]
 assign      rowscr_en = ~scont[0];    // = ~ppi0_c[1]
@@ -162,7 +170,7 @@ assign IPLn     = { blank4 ? vbl_irqn : mcu_ctrl[2], mcu_ctrl[1:0] };
 assign VPAn     = inta_n;
 
 wire        bus_cs   = rom_cs | ram_cs | vram_cs | char_cs | objram_cs | pal_cs |
-                       subram_cs | roadram_cs | io_cs;
+                       subram_cs | roadram_cs | io_cs | subrom_cs;
 // VWAIT: the board stalls the main CPU off video RAM until the video's fetch
 // phase for the layer it is addressing reaches the CPU's slot. IC106 (CK-2605
 // 315-5168, control sheet 1/7) decides it from /VRAM, AD1, AD15, H3, HA3, HB3 and
@@ -199,7 +207,7 @@ end
 
 wire        vwait    = vram_acc & ~vw_grant;
 wire        bus_busy = (rom_cs & ~(fd1089 ? fd1089_ok : rom_ok_dly)) |
-                       (vram_cs & ~vram_ok_dly) | vwait;
+                       (vram_cs & ~vram_ok_dly) | (subrom_cs & ~subrom_ok_dly) | vwait;
 
 jtframe_okdly u_rom_okdly(
     .rst    ( rst        ),
@@ -217,6 +225,14 @@ jtframe_okdly u_vram_okdly(
     .ok_dly ( vram_ok_dly )
 );
 
+jtframe_okdly u_subrom_okdly(
+    .rst    ( rst           ),
+    .clk    ( clk           ),
+    .cs     ( subrom_cs     ),
+    .ok     ( subrom_ok     ),
+    .ok_dly ( subrom_ok_dly )
+);
+
 always @(posedge clk, posedge rst) begin
     if( rst ) begin
         rom_cs     <= 0;
@@ -228,19 +244,23 @@ always @(posedge clk, posedge rst) begin
         subram_cs  <= 0;
         roadram_cs <= 0;
         io_cs      <= 0;
+        subrom_cs  <= 0;
     end else begin
         if( mcu_bus ? mcu_acc : (!ASn && FC!=3'b111 && {UDSn,LDSn}!=2'b11) ) begin
+            // sharrier_map / hangon_map
             rom_cs    <= A[23:18]==6'd0;             // 000000-03ffff
-            ram_cs    <= A[23:14]==10'h010;          // 040000-043fff
-            vram_cs   <= A[23:15]==9'h020;           // 100000-107fff, tileram
+            ram_cs    <= hangon ? A[23:14]==10'h083 : A[23:14]==10'h010; // 20c000 / 040000
+            vram_cs   <= hangon ? A[23:14]==10'h100 : A[23:15]==9'h020;  // 400000 / 100000, tileram
             // Text RAM plus the tile-map registers, a BRAM inside jts16_char
-            char_cs   <= A[23:12]==12'h108;          // 108000-108fff, textram
+            char_cs   <= A[23:12]==(hangon ? 12'h410 : 12'h108);         // 410000 / 108000, textram
             // 109000-10ffff is left undecoded: sharrier_map maps nothing there.
-            objram_cs <= A[23:12]==12'h130;          // 130000-130fff
-            pal_cs    <= A[23:12]==12'h110;          // 110000-110fff
-            io_cs     <= A[23:16]==8'h14;            // 140000-14ffff, mirrored
-            subram_cs <= A[23:16]==8'h12 && A[15:14]==2'b01; // 124000-127fff
+            objram_cs <= hangon ? A[23:11]==13'hc00 : A[23:12]==12'h130; // 600000 / 130000
+            pal_cs    <= A[23:12]==(hangon ? 12'ha00 : 12'h110);         // a00000 / 110000
+            io_cs     <= hangon ? A[23:21]==3'd7 : A[23:16]==8'h14;      // e00000 / 140000, mirrored
+            subram_cs <= hangon ? A[23:14]==10'h31f :                    // c7c000 / 124000
+                                  A[23:16]==8'h12 && A[15:14]==2'b01;
             roadram_cs<= A[23:12]==12'hc68;          // c68000-c68fff
+            subrom_cs <= hangon && A[23:18]==6'h30;  // c00000-c3ffff
         end else begin
             rom_cs     <= 0;
             ram_cs     <= 0;
@@ -251,21 +271,25 @@ always @(posedge clk, posedge rst) begin
             subram_cs  <= 0;
             roadram_cs <= 0;
             io_cs      <= 0;
+            subrom_cs  <= 0;
         end
     end
 end
 
-wire ppi0_cs = io_cs & (A[5:4]==2'd0);  // 140000, video_lamps_w, tilemap_sound_w
-wire ppi1_cs = io_cs & (A[5:4]==2'd2);  // 140020, sub_control_adc_w
+// 0 PPI0, 1 inputs, 2 PPI1, 3 ADC. Hang-On: e00000, e01000, e03000, e03021
+wire [1:0] io_sel  = hangon ? { A[13], A[13] ? A[5] : A[12] } : A[5:4];
+wire ppi0_cs = io_cs & (io_sel==2'd0);  // video_lamps_w, tilemap_sound_w
+wire ppi1_cs = io_cs & (io_sel==2'd2);  // sub_control_adc_w
 wire LDSWn   = RnW | LDSn;
 
 always @(*) begin
     case( A[2:1] )
-        2'd0: cab_dout = { cab1p ? { 1'b1, cab_1p[0], 2'b11 } : { joystick1[6:4], cab_1p[0] },
+        2'd0: cab_dout = { cab1p  ? { 1'b1, cab_1p[0], 2'b11 } :
+                           hangon ? { 3'b111, cab_1p[0] } : { joystick1[6:4], cab_1p[0] },
                            service, dip_test, coin[1:0] };
-        2'd1: cab_dout = 8'hff;
-        2'd2: cab_dout = dipsw_a;
-        2'd3: cab_dout = dipsw_b;
+        2'd1: cab_dout = hangon ? dipsw_a : 8'hff;
+        2'd2: cab_dout = hangon ? dipsw_b : dipsw_a;
+        2'd3: cab_dout = hangon ? 8'hff   : dipsw_b;
     endcase
 end
 
@@ -286,6 +310,13 @@ always @(*) begin
             2'd2: adc_val = an_y;     // bank up/down
             2'd3: adc_val = an_x;     // steering, reversed in jtharier_cab
         endcase
+    else if( adc==3'd3 )
+        case( adc_ch )
+            2'd0: adc_val = an_x;     // steering
+            2'd1: adc_val = an_gas;
+            2'd2: adc_val = an_brake;
+            default: adc_val = 8'h00;
+        endcase
     else
         case( adc_ch )
             2'd0: adc_val = an_x;
@@ -294,11 +325,11 @@ always @(*) begin
         endcase
 end
 always @(*) begin
-    case( A[5:4] )
+    case( io_sel )
         2'd0:    io_dout = ppi0_dout;
         2'd1:    io_dout = cab_dout;
         2'd2:    io_dout = ppi1_dout;
-        default: io_dout = adc_val;         // 140030, ADC0804
+        default: io_dout = adc_val;         // ADC0804
     endcase
 end
 
@@ -360,6 +391,8 @@ always @(posedge clk) begin
                objram_cs ? objram_dout           :
                pal_cs    ? pal_dout              :
                subram_cs ? subram_dout           :
+               subrom_cs ? subrom_data           :
+               roadram_cs? road_dout             :
                io_cs     ? { 8'hff, io_dout }    : 16'hffff;
 end
 
@@ -468,6 +501,7 @@ end
 jtharier_dtack_cen u_dtack(
     .rst        ( rst         ),
     .clk        ( clk         ),
+    .hangon     ( hangon      ),
     .cpu_cen    ( cpu_cen     ),
     .cpu_cenb   ( cpu_cenb    ),
     .UDSn       ( UDSn        ),
@@ -523,6 +557,7 @@ initial begin
     subram_cs  = 0;
     roadram_cs = 0;
     io_cs      = 0;
+    subrom_cs  = 0;
     st_dout   = 0;
 end
 
@@ -540,6 +575,7 @@ assign dsn      = 3;
 assign cpu_cen  = 0;
 assign cpu_cenb = 0;
 assign video_en = 1;   // unblanked: x here reaches colmix's /KILL latch
+assign shade0   = 0;
 assign colscr_en= 0;
 assign rowscr_en= 0;
 

--- a/cores/harier/hdl/jtharier_obj.v
+++ b/cores/harier/hdl/jtharier_obj.v
@@ -6,7 +6,7 @@
     family shape (jtoutrun_obj):
 
       jtharier_obj_scan  walks the object table, per-line address stepping
-      jtharier_obj_draw  fetches the 32-bit sprite ROM, 8 px/word, h-shrink
+      jtharier_obj_draw  fetches the sprite ROM, 8 px/word (Hang-On 4), h-shrink
       jtframe_obj_buffer   double line buffer, scanned out as obj_pxl
 
     Output pxl feeds jts16_tilemap.obj_pxl (contract in jts16_prio.v):
@@ -22,6 +22,7 @@ module jtharier_obj(
     input              rst,
     input              clk,
     input              pxl_cen,
+    input              hangon,
 
     output     [11:1]  tbl_addr,
     input      [15:0]  tbl_dout,
@@ -49,7 +50,7 @@ wire        dr_start, dr_busy;
 wire [ 8:0] dr_xpos;
 wire [15:0] dr_offset;   // [15] = hflip
 wire [ 2:0] dr_bank;
-wire        dr_prio;
+wire [ 1:0] dr_prio;
 wire [ 5:0] dr_pal;
 wire        dr_shadow;
 wire [ 6:0] dr_hzoom;
@@ -61,6 +62,7 @@ wire        bf_we;
 jtharier_obj_scan u_scan(
     .rst        ( rst       ),
     .clk        ( clk       ),
+    .hangon     ( hangon    ),
     .vrender    ( vrender   ),
     .hstart     ( hstart    ),
 
@@ -84,13 +86,14 @@ jtharier_obj_draw u_draw(
     .rst        ( rst       ),
     .clk        ( clk       ),
     .hstart     ( hstart    ),
+    .hangon     ( hangon    ),
 
     .start      ( dr_start  ),
     .busy       ( dr_busy   ),
     .xpos       ( dr_xpos   ),
     .offset     ( dr_offset ),
     .bank       ( dr_bank   ),
-    .sh_prio    ( dr_prio   ),
+    .prio       ( dr_prio   ),
     .pal        ( dr_pal    ),
     .shadow     ( dr_shadow ),
     .hzoom      ( dr_hzoom  ),

--- a/cores/harier/hdl/jtharier_obj_draw.v
+++ b/cores/harier/hdl/jtharier_obj_draw.v
@@ -17,27 +17,31 @@
     The row ends when the last pixel DRAWN in a word is 0xF. pix 0 and 0xF are
     both transparent; 0xF also stops the row.
 
-    obj_pxl = { prio[1:0], pal[5:0], pix[3:0] }, prio = { sh_prio, 1'b1 };
+    obj_pxl = { prio[1:0], pal[5:0], pix[3:0] }; Space Harrier prio = { bit14, 1'b1 }.
     pal==6'h3f is shadow (segahang.cpp:282). obj_data[31:28] is the first
     non-flipped pixel -- the endianness jtframe's 32-bit obj read gives.
+
+    Hang-On: 4-pixel 16-bit words; each 32-bit read holds two, byte-swapped:
+    even {[7:0],[15:8]}, odd {[23:16],[31:24]}.
 */
 
 module jtharier_obj_draw(
     input              rst,
     input              clk,
     input              hstart,
+    input              hangon,
 
     input              start,
     output reg         busy,
     input      [ 8:0]  xpos,
     input      [15:0]  offset,    // [15] = hflip, [14:0] = word offset within bank
     input      [ 2:0]  bank,
-    input              sh_prio,
+    input      [ 1:0]  prio,
     input      [ 5:0]  pal,
     input              shadow,
     input      [ 6:0]  hzoom,     // MAME value: (field & 0x3f) << 1
 
-    // Sprite ROM (1 MB, 32-bit reads)
+    // Sprite ROM (1 MB, 32-bit reads; Hang-On takes 16-bit words from them)
     input              obj_ok,
     output reg         obj_cs,
     output     [19:2]  obj_addr,
@@ -51,7 +55,7 @@ module jtharier_obj_draw(
 localparam [1:0] IDLE=2'd0, FETCH=2'd1, DRAW=2'd2;
 
 reg  [ 1:0] st;
-reg  [ 2:0] k;             // nibble index within the current 32-bit word
+reg  [ 2:0] k;             // nibble index within the current word
 reg  [31:0] pxl_data;
 reg  [14:0] cur;           // 15-bit word address within the bank (wraps at 0x7fff)
 reg  [ 7:0] xacc;
@@ -59,10 +63,13 @@ reg         hflip, last_word, fetch_dly;
 
 wire [ 3:0] cur_pxl;
 wire [ 8:0] xsum;
-wire        emit, line_end;
+wire        emit, line_end, word_end;
+wire [15:0] w16 = cur[0] ? { obj_data[23:16], obj_data[31:24] } :
+                           { obj_data[ 7: 0], obj_data[15: 8] };
 
 assign cur_pxl  = hflip ? pxl_data[3:0] : pxl_data[31-:4];
-assign obj_addr = { bank, cur };
+assign obj_addr = hangon ? { 1'b0, bank, cur[14:1] } : { bank, cur };
+assign word_end = hangon ? k[1:0]==2'd3 : &k;
 assign xsum     = { 1'b0, xacc } + { 2'b0, hzoom };
 assign emit     = ~xsum[8];
 // Must stop at the buffer end: bf_addr wraps otherwise and corrupts the line.
@@ -70,7 +77,7 @@ assign line_end = st==DRAW && emit && bf_addr==9'h1ff;
 
 assign bf_we   = st==DRAW && emit && cur_pxl!=4'h0 && cur_pxl!=4'hf;
 // per-pixel shadow: shadow-enabled AND pix==0xA (segahang.cpp:282, (pix&0x80f)==0x00a)
-assign bf_data = { sh_prio, 1'b1, (shadow && cur_pxl==4'ha) ? 6'h3f : pal, cur_pxl };
+assign bf_data = { prio, (shadow && cur_pxl==4'ha) ? 6'h3f : pal, cur_pxl };
 
 always @(posedge clk, posedge rst) begin
     if( rst ) begin
@@ -104,8 +111,10 @@ always @(posedge clk, posedge rst) begin
             FETCH: begin
                 fetch_dly <= 0;
                 if( !fetch_dly && obj_ok ) begin
-                    pxl_data  <= obj_data;
-                    last_word <= &(hflip ? obj_data[31-:4] : obj_data[3:0]);
+                    pxl_data  <= !hangon ? obj_data :
+                                 hflip   ? { 16'd0, w16 } : { w16, 16'd0 };
+                    last_word <= hangon ? &(hflip ? w16[15:12]      : w16[3:0]) :
+                                          &(hflip ? obj_data[31-:4] : obj_data[3:0]);
                     obj_cs    <= 0;
                     k         <= 0;
                     st        <= DRAW;
@@ -120,7 +129,7 @@ always @(posedge clk, posedge rst) begin
                     busy   <= 0;
                     obj_cs <= 0;
                     st     <= IDLE;
-                end else if( &k ) begin
+                end else if( word_end ) begin
                     if( last_word ) begin
                         busy <= 0;
                         st   <= IDLE;

--- a/cores/harier/hdl/jtharier_obj_scan.v
+++ b/cores/harier/hdl/jtharier_obj_scan.v
@@ -20,6 +20,8 @@
       +6  -ooooooo oooooooo   base offset within the bank
       +8  --zzzzzz --------   hzoom
       +8  -------- --zzzzzz   vzoom
+    Hang-On (hangon, sega16sp.cpp:109): +4 is a signed 16-bit pitch; +8 holds
+    colour [13:8], zoom [7:2] (hzoom = vzoom) and priority [1:0]; no shadow bit.
     bottom > 0xF0 ends the list; skip if top >= bottom. Device origin is
     (189,-1), so device y = vrender-1.
 
@@ -36,6 +38,7 @@
 module jtharier_obj_scan(
     input              rst,
     input              clk,
+    input              hangon,
 
     input      [ 8:0]  vrender,
     input              hstart,
@@ -53,7 +56,7 @@ module jtharier_obj_scan(
     output reg [ 8:0]  dr_xpos,
     output reg [15:0]  dr_offset,   // [15] = hflip
     output reg [ 2:0]  dr_bank,
-    output reg         dr_prio,
+    output reg [ 1:0]  dr_prio,
     output reg [ 5:0]  dr_pal,
     output reg         dr_shadow,   // shadow ENABLED for this sprite
     output reg [ 6:0]  dr_hzoom
@@ -72,7 +75,8 @@ reg  [ 8:0] xpos;
 reg signed [15:0] pitch;
 reg  [15:0] addr;
 reg  [ 5:0] vzoom, hzoom6, pal;
-reg         prio, shadow_dis;
+reg  [ 1:0] prio;
+reg         shadow_dis;
 reg  [15:0] scr;            // running address latched from the private scratch RAM
 
 // Private scratch RAM: the +E running address, one word per sprite
@@ -152,10 +156,9 @@ always @(posedge clk, posedge rst) begin
             end
             3: begin                   // tbl_dout = +4 : shadow / prio / colour / pitch
                 shadow_dis  <= tbl_dout[15];
-                prio        <= tbl_dout[14];
+                prio        <= { tbl_dout[14], 1'b1 };
                 pal         <= tbl_dout[13:8];
-                pitch[6:0]  <= tbl_dout[6:0];
-                pitch[15:7] <= {9{tbl_dout[6]}};        // sext 7-bit
+                pitch       <= hangon ? tbl_dout : { {9{tbl_dout[6]}}, tbl_dout[6:0] };
             end
             4: begin                   // tbl_dout = +6 : flip + base offset
                 addr <= tbl_dout;
@@ -168,8 +171,12 @@ always @(posedge clk, posedge rst) begin
                 end
             end
             5: begin                   // tbl_dout = +8 : hzoom / vzoom
-                hzoom6 <= tbl_dout[13:8];
-                vzoom  <= tbl_dout[ 5:0];
+                hzoom6 <= hangon ? tbl_dout[7:2] : tbl_dout[13:8];
+                vzoom  <= hangon ? tbl_dout[7:2] : tbl_dout[ 5:0];
+                if( hangon ) begin     // colour / zoom / priority
+                    pal  <= tbl_dout[13:8];
+                    prio <= tbl_dout[ 1:0];
+                end
             end
             6: begin                   // zoom_data valid next cycle
                 scr <= scr_dout;
@@ -186,7 +193,7 @@ always @(posedge clk, posedge rst) begin
                     dr_bank   <= bank;
                     dr_prio   <= prio;
                     dr_pal    <= pal;
-                    dr_shadow <= ~shadow_dis;
+                    dr_shadow <= ~shadow_dis & ~hangon;
                     dr_hzoom  <= { hzoom6, 1'b0 };      // MAME: (field & 0x3f) << 1
                     dr_start  <= 1;
                     cur_obj   <= cur_obj + 1'd1;

--- a/cores/harier/hdl/jtharier_road.v
+++ b/cores/harier/hdl/jtharier_road.v
@@ -30,6 +30,7 @@ module jtharier_road(
     input             rst,
     input             clk,
     input             pxl_cen,
+    input             hangon,
 
     input             hs,
     input      [ 8:0] vdump,      // line being displayed. NOT vrender: this module was
@@ -111,7 +112,9 @@ assign rdrom_addr = { idx_l, ctr9n9p[5:0] };
 // ss8j bit 0 swaps the bit order: normal reads bit (7-ctr9m), swapped ctr9m.
 wire [2:0] bitpos = ss8j[0] ? (3'd7 - ctr9m) : ctr9m;
 wire       oe     = (ctr9n9p[7:6]==2'b11);              // /OE = AND of 9N bits 2,3
-wire       ce     = ~control[9];                        // Space Harrier: ctrl[9] -> /CE
+// ctrl[9] is the road ROM /CE on Space Harrier; on Hang-On it forces ff9j2 set
+wire       ce     = hangon | ~control[9];
+wire       ff9j2_f = ff9j2 | (hangon & ~control[9]);
 reg  [1:0] md;
 reg  [1:0] mdc;         // md clamped for colour select
 reg        cbit;
@@ -134,7 +137,7 @@ end
 reg  [10:0] pxl_nx;
 always @(*) begin
     mdc = 2'd0; cbit = 1'b0;
-    if( ff9j2 && md==2'd3 ) begin
+    if( ff9j2_f && md==2'd3 ) begin
         // background solid fill: color0 holds two 6-bit selections
         pxl_nx = COLORBASE2 | { 5'd0, (select ? color0[5:0] : color0[13:8]) };
     end else begin

--- a/cores/harier/hdl/jtharier_roadarb.v
+++ b/cores/harier/hdl/jtharier_roadarb.v
@@ -64,7 +64,8 @@ always @(posedge clk, posedge rst) begin
     end
 end
 
-assign ram_addr = sub_cs ? sub_addr : pend_addr;
+// idle: follow the main address so road RAM reads back
+assign ram_addr = sub_cs ? sub_addr : pend ? pend_addr : main_addr;
 assign ram_din  = sub_cs ? sub_dout : pend_din;
 assign ram_we   = sub_cs ? (~sub_rnw ? ~sub_dsn : 2'b00) :
                   pend   ? pend_we : 2'b00;

--- a/cores/harier/hdl/jtharier_sub.v
+++ b/cores/harier/hdl/jtharier_sub.v
@@ -5,6 +5,7 @@
 module jtharier_sub(
     input              rst,
     input              clk,
+    input              hangon,
 
     // Held by the main CPU through the sub 8255 port A
     input              rstn,
@@ -103,6 +104,7 @@ end
 jtharier_dtack_cen u_dtack(
     .rst        ( rst         ),
     .clk        ( clk         ),
+    .hangon     ( hangon      ),
     .cpu_cen    ( cpu_cen     ),
     .cpu_cenb   ( cpu_cenb    ),
     .UDSn       ( UDSn        ),

--- a/cores/harier/hdl/jtharier_video.v
+++ b/cores/harier/hdl/jtharier_video.v
@@ -12,6 +12,9 @@ module jtharier_video(
     input              rowscr_en,   // SCONT0 from PPI0 port C (main.v)
     input              vfix_en,     // optional 'V' glyph fix, see below
     input              flip,
+    input              hangon,
+    input              hicol,
+    input              shade0,
 
     // Main CPU interface
     input              dip_pause,
@@ -181,6 +184,7 @@ jtharier_road u_road(
     .rst        ( rst          ),
     .clk        ( clk          ),
     .pxl_cen    ( pxl_cen      ),
+    .hangon     ( hangon       ),
     .hs         ( HS           ),
     .vdump      ( vdump        ),
 
@@ -201,6 +205,7 @@ jtharier_obj u_obj(
     .rst        ( rst         ),
     .clk        ( clk         ),
     .pxl_cen    ( pxl_cen     ),
+    .hangon     ( hangon      ),
 
     .tbl_addr   ( objdma_addr ),
     .tbl_dout   ( objdma_dout ),
@@ -241,6 +246,8 @@ jtharier_colmix u_colmix(
     .pal_addr     ( pal_vaddr    ),
     .pal_data     ( pal_vdata    ),
     .shadow       ( shadow       ),
+    .hicol        ( hicol        ),
+    .shade0       ( shade0       ),
     .gfx_en       ( gfx_en       ),
     .red          ( red          ),
     .green        ( green        ),


### PR DESCRIPTION
adds Hang-On to harier: main and sub CPU map and clock, inputs and pedals, road control bit 9, SHADER shadow/hilight and the Hang-On sprite format.

Sound needs the T80 EI/NMI fix, PR #1602 without it the sound fails fairly spectacularly after a short, random time during play